### PR TITLE
Fix for issue #42.

### DIFF
--- a/theories/Subterm.v
+++ b/theories/Subterm.v
@@ -148,7 +148,7 @@ Ltac sigma_pack t :=
   let xpack := fresh "pack" in
   uncurry_hyps packhyps; 
     (progress (set(xpack := t) in |- ;
-               cbv in xpack; revert xpack;
+               cbv beta iota zeta in xpack; revert xpack;
                pattern sigma packhyps; 
                clearbody packhyps;
                revert packhyps;


### PR DESCRIPTION
[sigma_pack] was a bit agressive while reducing the term to pack.

I am creating a PR just in case there was a further reason for having a full reduction in this tactic.