### PR TITLE
Add a target to Makefile.local

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -25,3 +25,12 @@ examples: examples/Makefile
 .PHONY: examples
 
 clean:: makefiles clean-examples clean-test-suite
+
+siteexamples: examples/*.glob
+	sh siteexamples.sh
+
+doc: html
+	mkdir -p html/api && ocamldoc -html -d html/api \
+		`ocamlfind query -r coq.intf coq.kernel coq.tactics coq.proofs \
+												coq.toplevel coq.ltac coq.plugins.extraction -i-format` \
+	  -rectypes -I src src/*.ml

--- a/Makefile.local
+++ b/Makefile.local
@@ -34,3 +34,8 @@ doc: html
 		`ocamlfind query -r coq.intf coq.kernel coq.tactics coq.proofs \
 												coq.toplevel coq.ltac coq.plugins.extraction -i-format` \
 	  -rectypes -I src src/*.ml
+
+toplevel: src/equations_plugin.cma bytefiles
+	"$(OCAMLFIND)" ocamlc -linkpkg -linkall -g $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) \
+		-package coq.toplevel,coq.plugins.extraction \
+	  $< $(COQLIB)/toplevel/coqtop_bin.ml -o coqtop_equations

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,9 +3,7 @@
 -R theories Equations
 -I theories
 -I examples
--extra-phony siteexamples "examples/*.glob" "sh siteexamples.sh"
--extra-phony doc "html" "mkdir -p html/api && ocamldoc -html -d html/api `ocamlfind query -r coq.intf coq.kernel coq.tactics coq.proofs coq.toplevel coq.ltac -i-format` -rectypes -I src src/*.ml"
-ZDEBUG = "-bin-annot -g -for-pack Equations -w -58"
+CAMLDEBUG = "-bin-annot -g -for-pack Equations -w -58"
 COQDOCFLAGS = "-parse-comments -utf8 -interpolate"
 src/equations_common.mli
 src/equations_common.ml


### PR DESCRIPTION
This adds a target to build a toplevel with a statically linked version of Equations, mainly for debug purposes.
We also fix #39 in another commit.

This is a PR because it relies on coq/coq#6593 being merged. Also, in case we don't want this target (I can keep this just on my side).