### PR TITLE
[build] Use Tacexpr module from packed Ltac_plugin [Coq's coq/coq/#6869]

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -21,12 +21,12 @@ open List
 open Libnames
 open Entries
 open Tacmach
-open Tacexpr
 open Tactics
 open Tacticals
 open Decl_kinds
 
 open Ltac_plugin
+open Tacexpr
 
 let ($) f g = fun x -> f (g x)
 let (&&&) f g (x, y) = (f x, g y)

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -9,6 +9,7 @@
 open EConstr
 open Environ
 open Names
+open Ltac_plugin
 
 type 'a peuniverses = 'a * EConstr.EInstance.t
 

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -10,6 +10,7 @@ open Constr
 open Environ
 open Names
 open Equations_common
+open Ltac_plugin
 
 type 'a with_loc = Loc.t * 'a
 


### PR DESCRIPTION
Due to an unfortunate upstream problem, Ltac's interfaces are not
packed into the Ltac_plugin pack.

This commit correctly qualifies `Tacexpr`, and makes Equations work
again with Coq's coq/coq/#6869