### PR TITLE
Adapting to Coq PR #7080: Rel.Context.t -> Constr.rel_context.

### DIFF
--- a/src/principles.mli
+++ b/src/principles.mli
@@ -61,7 +61,7 @@ val replace_vars_context :
   Equations_common.rel_declaration list ->
   int * Equations_common.rel_declaration list
 val pr_where :
-  Environ.env -> Evd.evar_map -> Context.Rel.t -> Covering.where_clause -> Pp.t
+  Environ.env -> Evd.evar_map -> Constr.rel_context -> Covering.where_clause -> Pp.t
 val where_instance : Covering.where_clause list -> constr list
 val arguments : Evd.evar_map -> constr -> constr array
 val unfold_constr : Evd.evar_map -> constr -> Proofview.V82.tac


### PR DESCRIPTION
In anticipation of #7080, if ever.