### PR TITLE
Fix for Coq PR#8554: term builder for tactic "change" takes an environment

### DIFF
--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -498,7 +498,7 @@ let ind_fun_tac is_rec f info fid split unfsplit progs =
 	  [to82 (set_eos_tac ()); to82 (fix recid (succ i));
 	   onLastDecl (fun decl gl ->
              let (n,b,t) = to_named_tuple decl in
-             let fixprot pats sigma =
+             let fixprot pats _env sigma =
 	       let c = 
                  mkLetIn (Anonymous, of_constr (UnivGen.constr_of_global (Lazy.force coq_fix_proto)),
                           of_constr (UnivGen.constr_of_global (Lazy.force coq_unit)), t) in


### PR DESCRIPTION
Trivial but breaking fix, to be apply jointly with coq/coq#8554.
