### PR TITLE
[coq] Fix some deprecation warnings + don't use debug printers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.d
 *.vo
 /Makefile

--- a/src/covering.ml
+++ b/src/covering.ml
@@ -192,7 +192,7 @@ let context_map_to_lhs ?(avoid = Id.Set.empty) ?loc (ctx, pats, _) =
 (** Pretty-printing *)
 
 let pr_constr_pat env sigma c =
-  let pr = Internal.print_constr_env env sigma c in
+  let pr = Printer.pr_econstr_env env sigma c in
   match kind sigma c with
   | App _ -> str "(" ++ pr ++ str ")"
   | _ -> pr
@@ -205,9 +205,9 @@ let pr_context env sigma c =
   let pr_decl env decl =
     let (id,b,t) = to_tuple decl in
     let bstr = match b with Some b ->
-      str ":=" ++ spc () ++ Internal.print_constr_env env sigma b | None -> mt() in
+      str ":=" ++ spc () ++ Printer.pr_econstr_env env sigma b | None -> mt() in
     let idstr = match id with Name id -> Id.print id | Anonymous -> str"_" in
-    idstr ++ bstr ++ str " : " ++ Internal.print_constr_env env sigma t
+    idstr ++ bstr ++ str " : " ++ Printer.pr_econstr_env env sigma t
   in
   let (_, pp) =
     match List.rev c with
@@ -991,15 +991,15 @@ let pr_splitting env sigma ?(verbose=false) split =
       let env' = push_rel_context (pi1 lhs) env in
       let ppwhere w =
         hov 2 (str"where " ++ Id.print w.where_id ++ str " : " ++
-               Internal.print_constr_env env'  sigma w.where_type ++
+               Printer.pr_econstr_env env'  sigma w.where_type ++
                str " := " ++ Pp.fnl () ++ aux w.where_splitting)
       in
       let ppwheres = prlist_with_sep Pp.fnl ppwhere wheres in
       let env'' = push_rel_context (where_context wheres) env' in
       ((match c with
           | RProgram c -> pplhs env' sigma lhs ++ str" := " ++
-                          Internal.print_constr_env env'' sigma c ++ 
-                          (verbose (str " : " ++ Internal.print_constr_env env'' sigma ty))
+                          Printer.pr_econstr_env env'' sigma c ++ 
+                          (verbose (str " : " ++ Printer.pr_econstr_env env'' sigma ty))
           | REmpty i -> pplhs env' sigma lhs ++ str" :=! " ++
                         pr_rel_name env'' i)
        ++ Pp.fnl () ++ ppwheres ++
@@ -1009,7 +1009,7 @@ let pr_splitting env sigma ?(verbose=false) split =
       (pplhs env' sigma lhs ++ str " split: " ++ pr_rel_name env' var ++
        Pp.fnl () ++
        verbose (str" : " ++
-                Internal.print_constr_env env' sigma ty ++ 
+                Printer.pr_econstr_env env' sigma ty ++ 
                 str " in context " ++ 
                 pr_context_map env sigma lhs ++ spc ()) ++
        (Array.fold_left 
@@ -1036,12 +1036,12 @@ let pr_splitting env sigma ?(verbose=false) split =
       in
       let env' = push_rel_context (pi1 lhs) env in
       hov 2 (pplhs env' sigma lhs ++ str " refine " ++ Id.print id ++ str" " ++ 
-             Internal.print_constr_env env' sigma (mapping_constr sigma revctx c) ++
-             verbose (str " : " ++ Internal.print_constr_env env' sigma cty ++ str" " ++
-                      Internal.print_constr_env env' sigma ty ++ str" " ++
+             Printer.pr_econstr_env env' sigma (mapping_constr sigma revctx c) ++
+             verbose (str " : " ++ Printer.pr_econstr_env env' sigma cty ++ str" " ++
+                      Printer.pr_econstr_env env' sigma ty ++ str" " ++
                       str " in " ++ pr_context_map env sigma lhs ++ spc () ++
                       str "New problem: " ++ pr_context_map env sigma newprob ++ str " for type " ++
-                      Internal.print_constr_env (push_rel_context (pi1 newprob) env) sigma newty ++ spc () ++
+                      Printer.pr_econstr_env (push_rel_context (pi1 newprob) env) sigma newty ++ spc () ++
                       spc () ++ str" eliminating " ++ pr_rel_name (push_rel_context (pi1 newprob) env) arg ++ spc () ++
                       str "Revctx is: " ++ pr_context_map env sigma revctx ++ spc () ++
                       str "New problem to problem substitution is: " ++ 
@@ -1113,7 +1113,7 @@ let split_var (env,evars) var delta =
       None
       (* 	  user_err_loc (dummy_loc, "split_var",  *)
       (* 		       str"Unable to split variable " ++ Name.print id ++ str" of (reduced) type " ++ *)
-      (* 			 Internal.print_constr_env (push_rel_context before env) newty  *)
+      (* 			 Printer.pr_econstr_env (push_rel_context before env) newty  *)
       (* 		       ++ str" to match a user pattern") *)
     else 
       let newdelta = after @ (make_def id b newty :: before) in
@@ -1283,17 +1283,17 @@ and interp_clause env evars data prev clauses' path (ctx,pats,ctx' as prob) lets
           | None ->
             CErrors.user_err ?loc:(Constrexpr_ops.constr_loc user) ~hdr:"covering"
               (str "Incompatible innaccessible pattern " ++
-               Internal.print_constr_env env' !evars userc ++
+               Printer.pr_econstr_env env' !evars userc ++
                spc () ++ str "should be convertible to " ++
-               Internal.print_constr_env env' !evars t)
+               Printer.pr_econstr_env env' !evars t)
         end
       | _ ->
         let t = pat_constr t in
         CErrors.user_err ?loc:(Constrexpr_ops.constr_loc user) ~hdr:"covering"
           (str "Pattern " ++
-           Internal.print_constr_env env' !evars userc ++
+           Printer.pr_econstr_env env' !evars userc ++
            spc () ++ str "is not inaccessible, but should refine pattern " ++
-           Internal.print_constr_env env' !evars t)
+           Printer.pr_econstr_env env' !evars t)
     in
     let check_innac ((loc,user), forced) =
       if Option.is_empty loc then
@@ -1308,7 +1308,7 @@ and interp_clause env evars data prev clauses' path (ctx,pats,ctx' as prob) lets
           let forcedsubst = substnl subst 0 forced in
           CErrors.user_err ?loc ~hdr:"covering"
             (str "This pattern must be innaccessible and equal to " ++
-             Internal.print_constr_env (push_rel_context ctx env) !evars forcedsubst)
+             Printer.pr_econstr_env (push_rel_context ctx env) !evars forcedsubst)
     in
     List.iter check_uinnac uinnacs;
     List.iter check_innac innacs

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -502,9 +502,9 @@ let pr_where env sigma ctx {where_id; where_nctx; where_prob; where_term;
   let open Pp in
   let envc = Environ.push_rel_context ctx env in
   let envw = push_named_context where_nctx env in
-  Termops.Internal.print_constr_env envc sigma where_term ++ fnl () ++
+  Printer.pr_econstr_env envc sigma where_term ++ fnl () ++
     str"where " ++ Names.Id.print where_id ++ str" : " ++
-    Termops.Internal.print_constr_env envc sigma where_type ++
+    Printer.pr_econstr_env envc sigma where_type ++
     str" := " ++ fnl () ++
     pr_context_map envw sigma where_prob ++ fnl () ++
     pr_splitting envw sigma where_splitting

--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -2,7 +2,6 @@ open Util
 open Names
 open Nameops
 open Constr
-open Termops
 open Environ
 open Globnames
 open Pp
@@ -122,7 +121,7 @@ let autorewrite_one b =
             (Proofview.Goal.enter
                begin fun gl -> let concl = Proofview.Goal.concl gl in
                                  Feedback.msg_debug (str"Trying " ++ pr_global global ++ str " on " ++
-                                                       Internal.print_constr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) concl);
+                                                       Printer.pr_econstr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) concl);
                                  tac end)
           else tac)
          (fun e -> if !debug then Feedback.msg_debug (str"failed"); aux rules)
@@ -148,7 +147,7 @@ let rec check_mutind env sigma k cl = match EConstr.kind sigma (Termops.strip_ou
     check_mutind (push_rel (Context.Rel.Declaration.LocalAssum (na, c1)) env) sigma (pred k) b
 | LetIn (na, c1, t, b) ->
     check_mutind (push_rel (Context.Rel.Declaration.LocalDef (na, c1, t)) env) sigma k b
-| _ -> CErrors.user_err (str"Not enough products in " ++ Internal.print_constr_env env sigma cl)
+| _ -> CErrors.user_err (str"Not enough products in " ++ Printer.pr_econstr_env env sigma cl)
 
 open Context.Named.Declaration
 (* Refine as a fixpoint *)
@@ -406,10 +405,10 @@ let rec aux_ind_fun info chop unfs unfids = function
              Feedback.msg_debug
              (str"Found path " ++ str (Id.to_string wherepath) ++ str" where: " ++
               pr_id s.where_id ++ str"term: " ++
-              Internal.print_constr_env env Evd.empty s.where_term ++
+              Printer.pr_econstr_env env Evd.empty s.where_term ++
               str" instance: " ++
               prlist_with_sep spc
-              (fun x -> Internal.print_constr_env env Evd.empty (EConstr.of_constr x)) args ++
+              (fun x -> Printer.pr_econstr_env env Evd.empty (EConstr.of_constr x)) args ++
               str" context map " ++
               pr_context_map env Evd.empty s.where_prob));
           let ind = Nametab.locate (qualid_of_ident wherepath) in

--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -488,7 +488,7 @@ let deletion ~(force:bool) : simplification_fun =
         let env = push_rel_context ctx env in
         raise (CannotSimplify (str
           "[deletion] Cannot simplify without K on type " ++
-          Termops.Internal.print_constr_env env !evd tA))
+          Printer.pr_econstr_env env !evd tA))
 
 let solution ~(dir:direction) : simplification_fun =
   fun (env : Environ.env) (evd : Evd.evar_map ref) ((ctx, ty) : goal) ->
@@ -615,7 +615,7 @@ let maybe_pack : simplification_fun =
       with Not_found ->
         raise (CannotSimplify (str
           "[noConfusion] Cannot simplify without K on type " ++
-          Termops.Internal.print_constr_env env !evd tA))
+          Printer.pr_econstr_env env !evd tA))
     in
     let tx =
       let _, _, tx, _ = Option.get (decompose_sigma !evd valsig) in
@@ -646,7 +646,7 @@ let apply_noconf : simplification_fun =
     with Not_found ->
       raise (CannotSimplify (str
         "[noConfusion] Cannot find an instance of NoConfusion for type " ++
-        Termops.Internal.print_constr_env env !evd tA))
+        Printer.pr_econstr_env env !evd tA))
   in
   let tapply_noconf = Globnames.ConstRef (Lazy.force EqRefs.apply_noConfusion) in
   let tB = EConstr.mkLambda (name, ty1, ty2) in

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -22,7 +22,6 @@ open Tacticals
 open Evarutil
 open Evar_kinds
 open Equations_common
-open Termops
 open Syntax
 open Covering
 open EConstr
@@ -217,7 +216,7 @@ let term_of_tree status isevar env0 tree =
             let ctx = cut_ctx @ new_ctx @ ctx' in
             msg_info(str"Simplifying term:");
             msg_info(let env = push_rel_context ctx env in
-              Internal.print_constr_env env !evd ty);
+              Printer.pr_econstr_env env !evd ty);
             msg_info(str"... in context:");
             msg_info(pr_context env !evd ctx)
           end;


### PR DESCRIPTION
Note that printers in `Termops` are debug printers so far.

Note that this won't work with 8.9 until https://github.com/coq/coq/pull/6524 is backported cc @silene , so I recommend waiting.