### PR TITLE
Adapting to Coq PR #8718: all hooks now take universes by default

### DIFF
--- a/src/eqdec.ml
+++ b/src/eqdec.ml
@@ -153,7 +153,7 @@ let derive_eq_dec env sigma ~polymorphic ind =
      let id = add_suffix ind.ind_name "_eqdec" in
      ignore(Obligations.add_definition id (to_constr !evdref stmt) (Evd.evar_universe_context !evdref)
                                        [||] ~tactic:(eqdec_tac ())
-				       ~hook:(Obligations.mk_univ_hook hook)))
+				       ~hook:(Lemmas.mk_hook hook)))
     indsl
 
 let () =

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -197,7 +197,7 @@ let define_principles flags fixprots progs =
            in
 	   ignore(Obligations.add_definition
                     ~kind:info.decl_kind
-		    ~hook:(Obligations.mk_univ_hook hook_eqs) ~reduce:(fun x -> x)
+		    ~hook:(Lemmas.mk_hook hook_eqs) ~reduce:(fun x -> x)
                     ~implicits:p.program_impls unfold_eq_id (to_constr evd stmt)
                     ~tactic:(of82 tac)
                     (Evd.evar_universe_context evd) [||])

--- a/src/noconf.ml
+++ b/src/noconf.ml
@@ -165,7 +165,7 @@ let derive_no_confusion env evd ~polymorphic (ind,u as indu) =
   let oblinfo, _, term, ty = Obligations.eterm_obligations env noid !evd 0
       (to_constr ~abort_on_undefined_evars:false !evd term)
       (to_constr !evd ty) in
-    ignore(Obligations.add_definition ~hook:(Obligations.mk_univ_hook hook) packid
+    ignore(Obligations.add_definition ~hook:(Lemmas.mk_hook hook) packid
              ~kind ~term ty ~tactic:(noconf_tac ())
 	      (Evd.evar_universe_context !evd) oblinfo)
 

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -889,7 +889,7 @@ let declare_funelim info env evd is_rec protos progs
   let tactic = ind_elim_tac elimc leninds (List.length progs) info indgr in
   let _ = e_type_of (Global.env ()) evd newty in
   ignore(Obligations.add_definition (Nameops.add_suffix id "_elim")
-	                            ~tactic ~hook:(Obligations.mk_univ_hook hookelim) ~kind:info.decl_kind
+	                            ~tactic ~hook:(Lemmas.mk_hook hookelim) ~kind:info.decl_kind
                                     (to_constr !evd newty) (Evd.evar_universe_context !evd) [||])
 
 let mkConj evd x y =
@@ -966,7 +966,7 @@ let declare_funind info alias env evd is_rec protos progs
   let stmt = to_constr !evd statement and f = to_constr !evd f in
   let ctx = Evd.evar_universe_context (if poly then !evd else Evd.from_env (Global.env ())) in
   try ignore(Obligations.add_definition
-             ~hook:(Obligations.mk_univ_hook hookind)
+             ~hook:(Lemmas.mk_hook hookind)
              ~kind:info.term_info.decl_kind
              indid stmt
              ~tactic:(ind_fun_tac is_rec f info id split unfsplit progs) ctx [||])
@@ -1232,7 +1232,7 @@ let build_equations with_ind env evd ?(alias:(constr * Names.Id.t * splitting) o
       ignore(Obligations.add_definition
                ~kind:info.decl_kind
                ideq (to_constr !evd c)
-               ~tactic:(of82 tac) ~hook:(Obligations.mk_univ_hook hook)
+               ~tactic:(of82 tac) ~hook:(Lemmas.mk_hook hook)
 	       (Evd.evar_universe_context !evd) [||])
     in List.iter proof stmts
   in List.iter proof ind_stmts

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -442,7 +442,7 @@ let define_tree is_recursive fixprots poly impls status isevar env (i, sign, ari
                       comp_obls = !compobls; user_obls = Id.Set.union !compobls !userobls } in
       hook split cmap term_info uctx
   in
-  let hook = Obligations.mk_univ_hook hook in
+  let hook = Lemmas.mk_hook hook in
   let reduce x =
     let flags = CClosure.betaiotazeta in
     (* let flags = match comp with None -> flags *)

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -247,7 +247,7 @@ let derive_subterm env sigma ~polymorphic (ind, u as indu) =
     let ctx = Evd.evar_universe_context evm in
     Obligations.add_definition id ~term:constr typ ctx
                                ~kind:(Decl_kinds.Global,polymorphic,Decl_kinds.Instance)
-                               ~hook:(Obligations.mk_univ_hook hook) ~tactic:(solve_subterm_tac ()) obls
+                               ~hook:(Lemmas.mk_hook hook) ~tactic:(solve_subterm_tac ()) obls
   in ignore(declare_ind ())
 
 let () =


### PR DESCRIPTION
@mattam82: this backward incompatible PR is to remain synchronous with #8718 (`mk_univ_hook` -> `mk_hook`).