### PR TITLE
Cleanup treatment of universe polymorphism.

### DIFF
--- a/src/eqdec.ml
+++ b/src/eqdec.ml
@@ -138,7 +138,7 @@ let derive_eq_dec env sigma ~polymorphic ind =
   in
   let indsl = Array.to_list info.mutind_inds in
   let indsl = List.map (fun ind -> ind, info_of ind) indsl in
-  let hook _ _ gr =
+  let hook _ _ _ gr =
     List.iter (fun (ind, (stmt, tc)) -> 
 	let ce = tc gr in
         let entry = (DefinitionEntry ce, IsDefinition Instance) in

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -147,9 +147,10 @@ let define_principles flags fixprots progs =
            let funf_cst = match info'.term_id with ConstRef c -> c | _ -> assert false in
            let () = if flags.polymorphic then evd := Evd.from_ctx ectx in
            let funfc = e_new_global evd info'.term_id in
-           let unfold_split = map_evars_in_split !evd (fun f x -> of_constr (cmap f x)) unfold_split in
+           let cmap' x = of_constr (cmap (EConstr.to_constr ~abort_on_undefined_evars:false !evd x)) in
+           let unfold_split = map_split cmap' unfold_split in
 	   let unfold_eq_id = add_suffix unfoldi "_eq" in
-           let hook_eqs _ subst grunfold =
+           let hook_eqs _ _obls subst grunfold =
 	     Global.set_strategy (ConstKey funf_cst) Conv_oracle.transparent;
              let () = (* Declare the subproofs of unfolding for where as rewrite rules *)
                let decl _ (_, id, _) =
@@ -163,7 +164,6 @@ let define_principles flags fixprots progs =
 	     let env = Global.env () in
 	     let () = if not flags.polymorphic then evd := (Evd.from_env env) in
              let prog' = { program_cst = funf_cst;
-                          program_cmap = cmap;
                           program_split = unfold_split;
                           program_split_info = info }
              in
@@ -226,12 +226,14 @@ let define_principles flags fixprots progs =
     let fn fixprot (p, prog) =
       let f =
         let gr = ConstRef prog.program_cst in
-        let (f, uc) = Typeops.constr_of_global_in_context env gr in
-        if flags.polymorphic then
-          let inst, ctx = ucontext_of_aucontext uc in
-          let () = evd := Evd.merge_context_set Evd.univ_rigid !evd ctx in
-          Constr.mkRef (global_of_constr f, inst)
-        else f
+        let inst =
+          if flags.polymorphic then
+            let ustate = prog.program_split_info.term_ustate in
+            let inst = Univ.UContext.instance (UState.context ustate) in
+            let () = evd := Evd.merge_universe_context !evd ustate in
+            inst
+          else Univ.Instance.empty
+        in Constr.mkRef (gr, inst)
       in
       (p, prog, f), of_tuple (Name p.program_id, Some (of_constr f), fixprot)
     in
@@ -580,10 +582,10 @@ let define_by_eqs opts eqs nt =
     let () = declare_wf_obligations info in
     let f_cst = match info.term_id with ConstRef c -> c | _ -> assert false in
     let () = evd := Evd.from_ctx ectx in
-    let split = map_evars_in_split !evd (fun f x -> of_constr (cmap f x)) split in
+    let cmap' x = of_constr (cmap (EConstr.to_constr ~abort_on_undefined_evars:false !evd x)) in
+    let split = map_split cmap' split in
     let p = nf_program_info !evd p in
     let compiled_info = { program_cst = f_cst;
-                          program_cmap = cmap;
                           program_split = split;
                           program_split_info = info } in
     progs.(i) <- Some (p, compiled_info);

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -941,11 +941,6 @@ let find_rectype env sigma ty =
 
 type identifier = Names.Id.t
 
-let ucontext_of_aucontext ctx =
-  let inst = Univ.AUContext.instance ctx in
-  inst, Univ.ContextSet.of_context
-        (Univ.UContext.make (inst, (Univ.AUContext.instantiate inst ctx)))
-
 let evd_comb0 f evd =
   let evm, r = f !evd in
   evd := evm; r

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -413,7 +413,5 @@ val find_rectype : Environ.env -> Evd.evar_map -> types -> Inductiveops.inductiv
 
 type identifier = Names.Id.t
 
-val ucontext_of_aucontext : Univ.AUContext.t -> Univ.Instance.t * Univ.ContextSet.t
-
 val evd_comb1 : (Evd.evar_map -> 'a -> Evd.evar_map * 'b) -> Evd.evar_map ref -> 'a -> 'b
 val evd_comb0 : (Evd.evar_map -> Evd.evar_map * 'b) -> Evd.evar_map ref -> 'b

--- a/src/noconf.ml
+++ b/src/noconf.ml
@@ -157,7 +157,7 @@ let derive_no_confusion env evd ~polymorphic (ind,u as indu) =
   let term = it_mkLambda_or_LetIn term ctx in
   let ty = it_mkProd_or_LetIn ty ctx in
   let _ = Equations_common.evd_comb1 (Typing.type_of env) evd term in
-  let hook _ectx vis gr =
+  let hook _ectx _evars vis gr =
     Typeclasses.add_instance
       (Typeclasses.new_instance tc empty_hint_info true gr)
   in

--- a/src/splitting.mli
+++ b/src/splitting.mli
@@ -33,6 +33,8 @@ val is_comp_obl : Evd.evar_map -> logical_rec option -> Evar_kinds.t -> bool
 
 type term_info = {
   term_id : Names.GlobRef.t;
+  term_ustate : UState.t;
+  term_evars : (Id.t * Constr.t) list;
   base_id : string;
   decl_kind : Decl_kinds.definition_kind;
   helpers_info : (Evar.t * int * identifier) list;
@@ -52,7 +54,6 @@ type program_info = {
 
 type compiled_program_info = {
     program_cst : Constant.t;
-    program_cmap : (Id.t -> Constr.t) -> Constr.t -> Constr.t;
     program_split : splitting;
     program_split_info : term_info }
 
@@ -67,7 +68,7 @@ val define_tree :
   Id.t * rel_context * types ->
   logical_rec option ->
   splitting ->
-  (splitting -> ((Id.t -> Constr.t) -> Constr.t -> Constr.t) ->
+  (splitting -> (Constr.t -> Constr.t) ->
    term_info ->
    UState.t -> unit) ->
   unit
@@ -76,10 +77,4 @@ val mapping_rhs : Evd.evar_map -> context_map -> splitting_rhs -> splitting_rhs
 val map_rhs :
   (constr -> constr) ->
   (int -> int) -> splitting_rhs -> splitting_rhs
-val map_evars_in_constr :
-  Evd.evar_map -> ((Id.t -> Constr.t) -> Constr.t -> 'b) -> constr -> 'b
 val map_split : (constr -> constr) -> splitting -> splitting
-val map_evars_in_split :
-  Evd.evar_map ->
-  ((Id.t -> Constr.t) -> Constr.t -> constr) ->
-  splitting -> splitting

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -230,7 +230,7 @@ let derive_subterm env sigma ~polymorphic (ind, u as indu) =
     in
     let ty = it_mkProd_or_LetIn ty parambinders in
     let body = it_mkLambda_or_LetIn (Option.get body) parambinders in
-    let hook _ vis gr =
+    let hook _ _ vis gr =
       let cst = match gr with ConstRef kn -> kn | _ -> assert false in
       let inst = Typeclasses.new_instance (fst kl) empty_hint_info
                                           global (ConstRef cst) in


### PR DESCRIPTION
- The obligation hook now returns the substitution from evars/obligation
  identifiers to their definitions in the universe context also passed
  to the hook (PR coq/coq#8889). We use that to normalize the splitting
  datastructure and get the right universes there.

- We keep the universe context of programs around so as to use it in
  derived definitions.