### PR TITLE
Adapting to Coq PR #8893 (moving evars_of_term from constr to econstr)

### DIFF
--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -102,9 +102,7 @@ let derive_noConfusion_package env sigma0 polymorphic (ind,u as indu) indid ~pre
   in
   let hook = Lemmas.mk_hook hook in
   let kind = Decl_kinds.(Global, polymorphic, Definition) in
-  let oblinfo, _, term, ty = Obligations.eterm_obligations env noid sigma 0
-      (to_constr ~abort_on_undefined_evars:false sigma term)
-      (to_constr sigma ty) in
+  let oblinfo, _, term, ty = Obligations.eterm_obligations env noid sigma 0 term ty in
     ignore(Obligations.add_definition ~hook packid
              ~kind ~term ty ~tactic
               (Evd.evar_universe_context sigma) oblinfo)

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -1169,21 +1169,21 @@ let solve_equations_obligations_program flags recids i sigma hook =
   let oblsid = Nameops.add_suffix i "_obligations" in
   let oblsinfo, (evids, cmap), term, ty =
     Obligations.eterm_obligations env oblsid sigma 0
-    ~status:(Evar_kinds.Define false) (EConstr.to_constr sigma term) (EConstr.to_constr sigma ty)
+    ~status:(Evar_kinds.Define false) term ty
   in
   let hook uctx evars locality gr =
     (* let l =
      *   Array.map_to_list (fun (id, ty, loc, s, d, tac) -> Libnames.qualid_of_ident id) obls in
      * Extraction_plugin.Table.extraction_inline true l; *)
     let sigma = Evd.merge_universe_context sigma uctx in
-    let evc id = List.assoc_f Id.equal id evars in
+    let evc id = EConstr.of_constr (List.assoc_f Id.equal id evars) in
     let sigma =
       Evd.fold_undefined
       (fun ev evi sigma ->
       let args =
-        Array.of_list (List.map (fun d -> Constr.mkVar (Context.Named.Declaration.get_id d))
+        Array.of_list (List.map (fun d -> EConstr.mkVar (Context.Named.Declaration.get_id d))
                        (Evd.evar_filtered_context evi)) in
-      let evart = Constr.mkEvar (ev, args) in
+      let evart = EConstr.mkEvar (ev, args) in
       let evc = cmap evc evart in
       Evd.define ev (whd_beta sigma (EConstr.of_constr evc)) sigma)
       sigma sigma

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -243,11 +243,7 @@ let derive_subterm env sigma ~polymorphic (ind, u as indu) =
     let _bodyty = e_type_of (Global.env ()) evm body in
     let _ty' = e_type_of (Global.env ()) evm ty in
     let evm = Evd.minimize_universes !evm in
-    let obls, _, constr, typ =
-      Obligations.eterm_obligations env id evm 0
-        (to_constr ~abort_on_undefined_evars:false evm body)
-        (to_constr ~abort_on_undefined_evars:false evm ty)
-    in
+    let obls, _, constr, typ = Obligations.eterm_obligations env id evm 0 body ty in
     let ctx = Evd.evar_universe_context evm in
     Obligations.add_definition id ~term:constr typ ctx
                                ~kind:(Decl_kinds.Global,polymorphic,Decl_kinds.Instance)


### PR DESCRIPTION
@mattam82, the changes here are about `Obligations.eterm_obligations` and are rather positive (removal of several instances of `EConstr.to_constr` on terms with potential evars).

To synchronize with coq/coq#8893.