### PR TITLE
Adapt to https://github.com/coq/coq/pull/9410

### DIFF
--- a/src/covering.mli
+++ b/src/covering.mli
@@ -75,14 +75,14 @@ type int_data = {
                Notation_term.scope_name option) list
 }
 
-val interp_program_body : Environ.env ->
+val interp_program_body : program_mode:bool -> Environ.env ->
            Evd.evar_map -> EConstr.rel_context ->
            Constrintern.internalization_env ->
            Vernacexpr.decl_notation list ->
            Syntax.program_body ->
            EConstr.types option -> Evd.evar_map * EConstr.constr
 
-val interp_constr_in_rhs_env :Environ.env ->
+val interp_constr_in_rhs_env : program_mode:bool -> Environ.env ->
   Evd.evar_map ref ->
   int_data ->
   EConstr.rel_context * Environ.env * int * EConstr.Vars.substl ->
@@ -91,7 +91,7 @@ val interp_constr_in_rhs_env :Environ.env ->
   EConstr.t option ->
   EConstr.constr * EConstr.types
 
-val interp_constr_in_rhs :
+val interp_constr_in_rhs : program_mode:bool ->
   env ->
   rel_context ->
   Evd.evar_map ref ->
@@ -168,6 +168,7 @@ val env_of_rhs :
 (** Covering computation *)
 
 val covering_aux :
+  program_mode:bool ->
   env ->
   Evd.evar_map ref ->
   program_info -> int_data ->
@@ -179,7 +180,7 @@ val covering_aux :
   rel_context -> constr ->
   ((pre_clause * (int * int)) list * splitting) option
 
-val covering : ?check_unused:bool ->
+val covering : program_mode:bool -> ?check_unused:bool ->
   env ->
   Evd.evar_map ref ->
   program_info -> int_data ->
@@ -244,6 +245,7 @@ val interp_arity : Environ.env ->
   program_info
 
 val coverings :
+  program_mode:bool ->
   Environ.env ->
   Evd.evar_map ref ->
   int_data ->

--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -437,7 +437,7 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
       let evd = ref evars in
       (* Produce a splitting tree. *)
       let split : Splitting.splitting =
-        Covering.covering env evd p data clauses [] prob [] ty
+        Covering.covering ~program_mode:false env evd p data clauses [] prob [] ty
       in
 
       let c, ty =

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -133,7 +133,7 @@ let define_principles flags rec_info fixprots progs =
     in
     build_equations flags.with_ind env !evd rec_info splits
 
-let define_by_eqs ~poly ~open_proof opts eqs nt =
+let define_by_eqs ~poly ~program_mode ~open_proof opts eqs nt =
   let with_eqns, with_ind =
     let try_bool_opt opt =
       if List.mem opt opts then false
@@ -155,7 +155,7 @@ let define_by_eqs ~poly ~open_proof opts eqs nt =
   let data, fixdecls, fixprots = compute_fixdecls_data env evd programs in
   let fixdecls = nf_rel_context_evar !evd fixdecls in
   let intenv = { rec_info; flags; fixdecls; intenv = data; notations = nt } in
-  let programs = coverings env evd intenv programs (List.map snd eqs) in
+  let programs = coverings ~program_mode env evd intenv programs (List.map snd eqs) in
   let env = Global.env () in (* coverings has the side effect of defining comp_proj constants for now *)
   let fix_proto_ref = destConstRef (Lazy.force coq_fix_proto) in
   let _kind = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
@@ -185,9 +185,9 @@ let define_by_eqs ~poly ~open_proof opts eqs nt =
   in
   define_programs env evd rec_info fixdecls flags programs hook
 
-let equations ~poly ~open_proof opts eqs nt =
+let equations ~poly ~program_mode ~open_proof opts eqs nt =
   List.iter (fun (((loc, i), nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ~loc i) false "def") eqs;
-  define_by_eqs ~poly ~open_proof opts eqs nt
+  define_by_eqs ~poly ~program_mode ~open_proof opts eqs nt
 
 let solve_equations_goal destruct_tac tac gl =
   let concl = pf_concl gl in

--- a/src/equations.mli
+++ b/src/equations.mli
@@ -11,7 +11,7 @@ open Names
 open Equations_common
 open Splitting
 
-val define_by_eqs : poly:bool -> open_proof:bool ->
+val define_by_eqs : poly:bool -> program_mode:bool -> open_proof:bool ->
   Syntax.equation_option list ->
   Syntax.pre_equations ->
   (Names.lstring * Constrexpr.constr_expr *
@@ -25,7 +25,7 @@ val define_principles :
   EConstr.t list ->
   (program * compiled_program_info) list -> unit
 
-val equations : poly:bool ->
+val equations : poly:bool -> program_mode:bool ->
   open_proof:bool ->
   Syntax.equation_option list ->
   Syntax.pre_equations ->

--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -390,13 +390,13 @@ let classify_equations x =
 }
 
 VERNAC COMMAND EXTEND Define_equations CLASSIFIED AS SIDEFF
-| #[ poly = polymorphic ] [ "Equations" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations ~poly ~open_proof:false opt (fst eqns) (snd eqns) }
+| #[ poly = polymorphic; program_mode = program ] [ "Equations" equation_options(opt) equations(eqns) ] ->
+    { Equations.equations ~poly ~program_mode ~open_proof:false opt (fst eqns) (snd eqns) }
 END
 
 VERNAC COMMAND EXTEND Define_equations_refine CLASSIFIED BY { classify_equations }
-| #[ poly = polymorphic ] [ "Equations?" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations ~poly ~open_proof:true opt (fst eqns) (snd eqns) }
+| #[ poly = polymorphic; program_mode = program ] [ "Equations?" equation_options(opt) equations(eqns) ] ->
+    { Equations.equations ~poly ~program_mode ~open_proof:true opt (fst eqns) (snd eqns) }
 END
 
 (* Dependent elimination using Equations. *)

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -221,7 +221,7 @@ let derive_no_confusion_hom env sigma0 ~polymorphic (ind,u as indu) =
                   program_arity = s}
   in
   let splitting =
-    Covering.covering
+    Covering.covering ~program_mode:false
       ~check_unused:false (* The catch-all clause might not be needed *)
       env evd p data clauses [] ctxmap [] s in
   let hook _ p terminfo =


### PR DESCRIPTION
We use the attribute system to make `Equations` support `Program`,
instead of relying on a global imperative flag.

This is to be merged only after https://github.com/coq/coq/pull/9410 is merged.