### PR TITLE
Basing API on Impargs.manual_implicits rather than Impargs.manual_explicitation

### DIFF
--- a/src/splitting.mli
+++ b/src/splitting.mli
@@ -97,7 +97,7 @@ val program_id : program -> Id.t
 val program_type : program -> EConstr.t
 val program_sign : program -> EConstr.rel_context
 val program_arity : program -> EConstr.t
-val program_impls : program -> Impargs.manual_explicitation list
+val program_impls : program -> Impargs.manual_implicits
 val program_rec : program -> program_rec_info option
 
 val pr_path : Evd.evar_map -> path -> Pp.t

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -280,7 +280,7 @@ type program_info = {
   program_sign : EConstr.rel_context;
   program_arity : EConstr.t;
   program_rec : program_rec_info option;
-  program_impls : Impargs.manual_explicitation list;
+  program_impls : Impargs.manual_implicits;
   program_implicits : Impargs.implicit_status list;
 }
 

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -147,7 +147,7 @@ type program_info = {
   program_sign : EConstr.rel_context;
   program_arity : EConstr.t;
   program_rec : program_rec_info option;
-  program_impls : Impargs.manual_explicitation list;
+  program_impls : Impargs.manual_implicits;
   program_implicits : Impargs.implicit_status list;
 }
 


### PR DESCRIPTION
Hi @mattam82. I don't know if you saw the discussion with @jashug at coq/coq#10231. We proposed to enforce by typing the invariants that manual implicit arguments are supposed to satisfy in `declare_manual_implicits` and I pushed a commit for that in coq/coq#10231.

In any case, this PR on Equations simply avoid referring to `Impargs.manual_explicitation` so that the implementation of `manual_implicits` can later be changed w/o Equations being affected, allowing future compatibility with coq/coq#10231.

As far as I can judge, it can be merge w/o waiting coq/coq#10231.