### PR TITLE
Adapting to Coq PR #8726 (more structured "locality" type).

### DIFF
--- a/src/equations.ml
+++ b/src/equations.ml
@@ -152,7 +152,7 @@ let define_by_eqs ~poly ~program_mode ~open_proof opts eqs nt =
   let programs = coverings env evd intenv programs (List.map snd eqs) in
   let env = Global.env () in (* coverings has the side effect of defining comp_proj constants for now *)
   let fix_proto_ref = destConstRef (Lazy.force coq_fix_proto) in
-  let _kind = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
+  let _kind = (Decl_kinds.Global Decl_kinds.ImportDefaultBehavior, poly, Decl_kinds.Definition) in
   let baseid =
     let p = List.hd programs in Id.to_string p.program_info.program_id in
   (* Necessary for the definition of [i] *)

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -101,7 +101,7 @@ let derive_noConfusion_package env sigma0 polymorphic (ind,u as indu) indid ~pre
       (Classes.mk_instance tc empty_hint_info true gr)
   in
   let hook = Lemmas.mk_hook hook in
-  let kind = Decl_kinds.(Global, polymorphic, Definition) in
+  let kind = Decl_kinds.(Global ImportDefaultBehavior, polymorphic, Definition) in
   let oblinfo, _, term, ty = Obligations.eterm_obligations env noid sigma 0 term ty in
     ignore(Obligations.add_definition ~hook packid
              ~kind ~term ty ~tactic

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -1068,7 +1068,7 @@ let error_complete () =
                 str "Use the \"Equations\" command to define it.")
 
 let solve_equations_obligations flags recids i sigma hook =
-  let kind = (Decl_kinds.Local, flags.polymorphic, Decl_kinds.(DefinitionBody Definition)) in
+  let kind = (Decl_kinds.Global Decl_kinds.ImportNeedQualified, flags.polymorphic, Decl_kinds.(DefinitionBody Definition)) in
   let evars = Evar.Map.bindings (Evd.undefined_map sigma) in
   let env = Global.env () in
   let types =
@@ -1159,7 +1159,7 @@ let solve_equations_obligations flags recids i sigma hook =
   pstate
 
 let solve_equations_obligations_program flags recids i sigma hook =
-  let kind = (Decl_kinds.Local, flags.polymorphic, Decl_kinds.(Definition)) in
+  let kind = (Decl_kinds.Global Decl_kinds.ImportNeedQualified, flags.polymorphic, Decl_kinds.(Definition)) in
   let env = Global.env () in
   let sigma, term = get_fresh sigma (Equations_common.logic_top_intro) in
   let sigma, ty = get_fresh sigma (Equations_common.logic_top) in
@@ -1265,7 +1265,7 @@ let define_programs (type a) env evd is_recursive fixprots flags ?(unfold=false)
     let programs = List.map (map_program (nf_evar sigma)) programs in
     let ustate = Evd.evar_universe_context sigma in
     let () = List.iter (fun (cst, _) -> add_hint true (program_id (List.hd programs)) cst) helpers in
-    hook recobls helpers ustate Decl_kinds.Global programs
+    hook recobls helpers ustate (Decl_kinds.Global Decl_kinds.ImportDefaultBehavior) programs
   in
   let recids = rec_type_ids is_recursive in
   match hook with
@@ -1274,14 +1274,14 @@ let define_programs (type a) env evd is_recursive fixprots flags ?(unfold=false)
     let hook recobls helpers ustate kind programs =
       let p = List.hd programs in
       let cst, _ = (destConst !evd p.program_term) in
-      call_hook recobls p helpers ustate Decl_kinds.Global (ConstRef cst) f
+      call_hook recobls p helpers ustate (Decl_kinds.Global Decl_kinds.ImportDefaultBehavior) (ConstRef cst) f
     in
     all_hook hook [] !evd, None
   | HookLater f ->
     let hook recobls helpers ustate kind programs =
       List.iteri (fun i p ->
           let cst, _ = (destConst !evd p.program_term) in
-          call_hook recobls p helpers ustate Decl_kinds.Global (ConstRef cst) (f i)) programs
+          call_hook recobls p helpers ustate (Decl_kinds.Global Decl_kinds.ImportDefaultBehavior) (ConstRef cst) (f i)) programs
     in
     if Evd.has_undefined !evd then
       if flags.open_proof then

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -246,7 +246,7 @@ let derive_subterm env sigma ~polymorphic (ind, u as indu) =
     let obls, _, constr, typ = Obligations.eterm_obligations env id evm 0 body ty in
     let ctx = Evd.evar_universe_context evm in
     Obligations.add_definition id ~term:constr typ ctx
-                               ~kind:(Decl_kinds.Global,polymorphic,Decl_kinds.Instance)
+                               ~kind:(Decl_kinds.Global Decl_kinds.ImportDefaultBehavior,polymorphic,Decl_kinds.Instance)
                                ~hook:(Lemmas.mk_hook hook) ~tactic:(solve_subterm_tac ()) obls
   in ignore(declare_ind ())
 


### PR DESCRIPTION
The main change is that flag `Global` becomes `Global ImportDefaultBehavior`. See coq/coq#8726.

Note 1: I kept the style of prefixing each individual call to a constructor of `Decl_kinds` by the module name, but I could make a factorization of the form `Decl_kinds.(...)` is you prefer.

Note 2: To be merged synchronously with coq/coq#8726.