### PR TITLE
Adapt to coq/coq#11027 (inductive entries use boolean for cumulativity)

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -712,7 +712,7 @@ let interp_arity env evd ~poly ~is_rec ~with_evars notations (((loc,i),rec_annot
     | Some (WellFounded (c, r)) -> Some (WellFounded (c, r))
   in
   let body = it_mkLambda_or_LetIn arity sign in
-  let _ = if not with_evars then Pretyping.check_evars env Evd.empty !evd body in
+  let _ = if not with_evars then Pretyping.check_evars env !evd body in
   let program_orig_type = it_mkProd_or_LetIn arity sign in
   let program_sort =
     let u = Sorts.univ_of_sort (Retyping.get_sort_of env !evd program_orig_type) in

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -1576,11 +1576,11 @@ let build_equations with_ind env evd ?(alias:alias option) rec_info progs =
                 mind_entry_finite = Declarations.Finite;
                 mind_entry_params = []; (* (identifier * local_entry) list; *)
                 mind_entry_inds = inds;
-                mind_entry_variance = None;
+                mind_entry_cumulative = false;
               }
     in
     let () = Goptions.set_bool_option_value_gen ~locality:Goptions.OptLocal ["Elimination";"Schemes"] false in
-    let kn = ComInductive.declare_mutual_inductive_with_eliminations inductive UnivNames.empty_binders [] in
+    let kn = DeclareInd.declare_mutual_inductive_with_eliminations inductive UnivNames.empty_binders [] in
     let () = Goptions.set_bool_option_value_gen ~locality:Goptions.OptLocal ["Elimination";"Schemes"] true in
     let sort = Inductiveops.top_allowed_sort (Global.env()) (kn,0) in
     let sort_suff = Indrec.elimination_suffix sort in

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -148,7 +148,7 @@ let derive_subterm env sigma ~poly (ind, u as indu) =
         mind_entry_inds = inds;
         mind_entry_private = None;
         mind_entry_universes = uctx;
-        mind_entry_variance = None;
+        mind_entry_cumulative = false;
       }
     in
     let k = ComInductive.declare_mutual_inductive_with_eliminations inductive UnivNames.empty_binders [] in


### PR DESCRIPTION
and check_evars uses optional argument for initial map