### PR TITLE
Adapting to Coq PR#10832 (extra scope argument to CNotation).

### DIFF
--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -257,7 +257,7 @@ let free_vars_of_constr_expr fid c =
              else l
            | Globnames.SynDef _ -> l
          with Not_found -> Id.Set.add id l)
-    | { CAst.v = CNotation ((InConstrEntrySomeLevel, "?( _ )"), _) } -> l
+    | { CAst.v = CNotation (_,(InConstrEntrySomeLevel, "?( _ )"), _) } -> l
     | c -> fold_constr_expr_with_binders (fun a l -> a::l) aux bdvars l c
   in aux [] Id.Set.empty c
 


### PR DESCRIPTION
This adapts to changes made by [Coq PR#10932](https://github.com/coq/coq/pull/10832)
in the syntax of `CNotation`. To be merged when Coq PR#10932 is merged.