### PR TITLE
Adapt to Coq PR #11602: support "only parsing" in where clause for notations

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -30,8 +30,7 @@ type int_data = {
   flags : flags;
   program_mode : bool;
   intenv : Constrintern.internalization_env;
-  notations : (Names.lstring * Constrexpr.constr_expr *
-               Notation_term.scope_name option) list
+  notations : Vernacexpr.decl_notation list
 }
 
 exception Conflict

--- a/src/covering.mli
+++ b/src/covering.mli
@@ -72,8 +72,7 @@ type int_data = {
   flags : flags;
   program_mode : bool;
   intenv : Constrintern.internalization_env;
-  notations : (Names.lstring * Constrexpr.constr_expr *
-               Notation_term.scope_name option) list
+  notations : Vernacexpr.decl_notation list
 }
 
 val add_wfrec_implicits : Syntax.rec_type ->

--- a/src/equations.mli
+++ b/src/equations.mli
@@ -17,8 +17,7 @@ val define_by_eqs
   -> open_proof:bool
   -> Syntax.equation_options
   -> Syntax.pre_equations
-  -> (Names.lstring * Constrexpr.constr_expr *
-      Notation_term.scope_name option) list
+  -> Vernacexpr.decl_notation list
   -> Lemmas.t option
 
 val define_principles :
@@ -30,17 +29,13 @@ val define_principles :
 val equations : poly:bool -> program_mode:bool ->
   Syntax.equation_options ->
   Syntax.pre_equations ->
-  (Names.lstring * Constrexpr.constr_expr *
-   Notation_term.scope_name option)
-  list ->
+  Vernacexpr.decl_notation list ->
   unit
 
 val equations_interactive : poly:bool -> program_mode:bool ->
   Syntax.equation_options ->
   Syntax.pre_equations ->
-  (Names.lstring * Constrexpr.constr_expr *
-   Notation_term.scope_name option)
-  list ->
+  Vernacexpr.decl_notation list ->
   Lemmas.t
 
 val solve_equations_goal :

--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -320,8 +320,10 @@ GRAMMAR EXTEND Gram
   ;
 
   where_rhs:
-    [ [ ntn = ne_lstring; ":="; c = constr;
-        scopt = OPT [ ":"; sc = IDENT -> { sc } ] -> { Inr (ntn, c, scopt) }
+    [ [ ntn = ne_lstring; ":="; c = constr; b = G_vernac.only_parsing;
+        scopt = OPT [ ":"; sc = IDENT -> { sc } ] -> {
+        Inr { Vernacexpr.decl_ntn_string = ntn; decl_ntn_interp = c;
+              decl_ntn_only_parsing = b; decl_ntn_scope = scopt } }
       | p = proto -> { Inl (p (Some Syntax.Nested)) } ] ]
   ;
 
@@ -342,8 +344,10 @@ GRAMMAR EXTEND Gram
   ;
 
   local_where_rhs:
-    [ [ ntn = ne_lstring; ":="; c = constr;
-        scopt = OPT [ ":"; sc = IDENT -> { sc } ] -> { Inr (ntn, c, scopt) }
+    [ [ ntn = ne_lstring; ":="; c = constr; b = G_vernac.only_parsing;
+        scopt = OPT [ ":"; sc = IDENT -> { sc } ] -> {
+        Inr { Vernacexpr.decl_ntn_string = ntn; decl_ntn_interp = c;
+              decl_ntn_only_parsing = b; decl_ntn_scope = scopt } }
       | p = proto -> { Inl (p (Some Syntax.Mutual)) } ] ]
   ;
   local_where:

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -576,7 +576,7 @@ let is_recursive i : 'a wheres -> bool = fun eqs ->
     | _ -> false
   and occur_eqns eqs = List.exists occur_eqn eqs
   and occurs_notations nts =
-    List.exists (fun (_, c, _) -> occur_var_constr_expr i c) nts
+    List.exists (fun nt -> occur_var_constr_expr i nt.Vernacexpr.decl_ntn_interp) nts
   and occurs eqs =
     List.exists (fun (_,eqs) -> occur_eqns eqs) (fst eqs) || occurs_notations (snd eqs)
   in occurs eqs


### PR DESCRIPTION
This consists in extending `Vernacexpr.decl_notation` with an only-parsing flag and to move its syntax to a record.

We extend `g_equations.mlg` so that it supports "only parsing" in its instances of `local_where_rhs` and `where_rhs`.

Maybe an overkill Coq PR, but at least this provides consistency with the whole design of `only parsing`.

To be merged synchronously with coq/coq#11602.