### PR TITLE
Fix issue #286: let-ins in constructors

### DIFF
--- a/src/context_map.mli
+++ b/src/context_map.mli
@@ -98,8 +98,11 @@ val make_permutation : ?env:Environ.env -> Evd.evar_map ->
   context_map -> context_map -> context_map
 
 val specialize_mapping_constr : Evd.evar_map -> context_map -> constr -> constr
-val rels_of_tele : 'a list -> constr list
-val patvars_of_tele : 'a list -> pat list
+val rels_of_ctx : ?with_lets:bool -> ('a,'b) Context.Rel.pt -> constr list
+
+val patvars_of_ctx : ?with_lets:bool -> ('a,'b) Context.Rel.pt -> pat list
+(** Includes lets by default *)
+
 val pat_vars_list : int -> pat list
 val intset_of_list : Int.Set.elt list -> Int.Set.t
 val split_context : int -> 'a list -> 'a list * 'a * 'a list
@@ -148,8 +151,8 @@ val new_strengthen :
   rel_context -> int -> ?rels:Int.Set.t -> constr ->
   context_map * context_map
 
-val id_pats : 'a list -> pat list
-val id_subst : 'a list -> 'a list * pat list * 'a list
+val id_pats : ('a, 'b) Context.Rel.pt -> pat list
+val id_subst : ('a, 'b) Context.Rel.pt -> ('a, 'b) Context.Rel.pt * pat list * ('a,'b) Context.Rel.pt
 val eq_context_nolet :
   env ->
   Evd.evar_map -> rel_context -> rel_context -> bool

--- a/src/covering.ml
+++ b/src/covering.ml
@@ -84,13 +84,16 @@ and unify_constrs env evd flex g l l' =
   | _, _ -> raise Conflict
 
 let flexible pats gamma =
-  let (_, flex) =
-    fold_left2 (fun (k,flex) pat decl ->
-        match pat with
-        | PInac _ -> (succ k, Int.Set.add k flex)
-        | p -> (succ k, flex))
-      (1, Int.Set.empty) pats gamma
-  in flex
+  let rec aux (k,flex) pats decls = 
+    match decls, pats with
+    | Context.Rel.Declaration.LocalAssum _ :: decls, pat :: pats ->
+        (match pat with
+        | PInac _ -> aux (succ k, Int.Set.add k flex) pats decls
+        | p -> aux (succ k, flex) pats decls)
+    | _ :: decls,  pats -> aux (succ k, flex) pats decls
+    | [], [] -> flex
+    | _ -> assert false
+  in aux (1, Int.Set.empty) pats gamma
 
 let rec accessible = function
   | PRel i -> Int.Set.singleton i
@@ -429,10 +432,11 @@ let unify_type env evars before id ty after =
           let env' = push_rel_context ctx env in
           let (indf, args) = find_rectype env' !evars ty in
           let ind, params = dest_ind_family indf in
-          let constr = applist (mkConstructUi (ind, succ i), params @ rels_of_tele ctx) in
-          let q = inaccs_of_constrs (rels_of_tele ctx) in	
+          let realargs = rels_of_ctx ~with_lets:false ctx in
+          let constr = applist (mkConstructUi (ind, succ i), params @ realargs) in
+          let q = inaccs_of_constrs realargs in	
           let constrpat = PCstr (((fst ind, succ i), snd ind), 
-                                 inaccs_of_constrs params @ patvars_of_tele ctx) in
+                                 inaccs_of_constrs params @ patvars_of_ctx ~with_lets:false ctx) in
           env', ctx, constr, constrpat, q, args)
         cstrs
     in
@@ -442,7 +446,7 @@ let unify_type env evars before id ty after =
           let fullctx = ctxc @ before in
           try
             let vs' = List.map (lift ctxclen) vs in
-            let p1 = lift_pats ctxclen (inaccs_of_constrs (rels_of_tele before)) in
+            let p1 = lift_pats ctxclen (inaccs_of_constrs (rels_of_ctx ~with_lets:false before)) in
             let flex = flexible (p1 @ q) fullctx in
             let s = unify_constrs env !evars flex fullctx vs' us in
             UnifSuccess (s, ctxclen, c, cpat)
@@ -502,6 +506,7 @@ let split_var (env,evars) var delta =
     | UnifSuccess ((ctx',s,ctx), ctxlen, cstr, cstrpat) ->
       (* ctx' |- s : before ; ctxc *)
       (* ctx' |- cpat : ty *)
+      if !debug then Feedback.msg_debug Pp.(str"cpat: " ++ pr_pat env !evars cstrpat);
       let cpat = specialize !evars s cstrpat in
       let ctx' = do_renamings env !evars ctx' in
       (* ctx' |- spat : before ; id *)
@@ -1204,7 +1209,7 @@ and interp_clause env evars p data prev clauses' path (ctx,pats,ctx' as prob)
             if List.exists (function PHide idx' -> idx == idx' | _ -> false)
                 (pi2 newprob_to_lhs) then
               PHide idx
-            else PRel idx) (rels_of_tele ctx) in
+            else PRel idx) (rels_of_ctx ctx) in
       (ctx, pats, ctx)
     in
     let newty =

--- a/src/covering.mli
+++ b/src/covering.mli
@@ -35,7 +35,7 @@ val unify_constrs :
   rel_context ->
   constr list ->
   constr list -> context_map
-val flexible : pat list -> 'a list -> Int.Set.t
+val flexible : pat list -> ('a,'b) Context.Rel.pt -> Int.Set.t
 val accessible : pat -> Int.Set.t
 val accessibles : pat list -> Int.Set.t
 val hidden : pat -> bool

--- a/src/sigma_types.ml
+++ b/src/sigma_types.ml
@@ -751,7 +751,7 @@ let smart_case (env : Environ.env) (evd : Evd.evar_map ref)
     let term = EConstr.mkConstructU (to_peuniverses summary.Inductiveops.cs_cstr) in
     let term = EConstr.mkApp (term, params) in
     let term = Vars.lift (summary.Inductiveops.cs_nargs) term in
-    let term = EConstr.mkApp (term, rel_vect 0 summary.Inductiveops.cs_nargs) in
+    let term = EConstr.mkApp (term, Context.Rel.to_extended_vect EConstr.mkRel 0 summary.Inductiveops.cs_args) in
     (* Indices are typed under [args @ ctx'] *)
     let indices = (Array.to_list indices) @ [term] in
     let args = summary.Inductiveops.cs_args in

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -60,6 +60,7 @@ issues/issue193.v
 issues/issue246.v
 issues/issue249.v
 issues/issue258.v
+issues/issue286.v
 noconf_simplify.v
 le.v
 LogicType.v

--- a/test-suite/issues/issue286.v
+++ b/test-suite/issues/issue286.v
@@ -1,0 +1,9 @@
+From Equations Require Import Equations.
+
+Axiom P : nat -> Type.
+
+Inductive foo : nat -> Type :=
+| foo_let n (j := n) (k : P n) : nat -> let m := n + j + 2 in P m -> foo m.
+
+Equations bar (n : nat) (x : foo n) : nat :=
+  bar _ (foo_let x k n y) := n.


### PR DESCRIPTION
Closes #286 

A bit of the code had to be adapted to take care of this but nothing terrible.
It will require some more parsing work to let users give their own names to the variables bound to let-ins, currently they're derived from the bindings used in the constructor declaration.