### PR TITLE
Fix issue #297: simplify mistreated lets

### DIFF
--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -687,6 +687,12 @@ let pre_solution ~(dir:direction) : simplification_fun =
     else tz, tx
   in
   let rel = EConstr.destRel !evd trel in
+  let () = 
+    try let decl = lookup_rel rel ctx in
+      if Context.Rel.Declaration.is_local_assum decl then ()
+      else raise (CannotSimplify (str "[solution] cannot apply to a let-bound variable"))
+    with Not_found -> assert false
+  in
   (* Check dependencies in both tA and term *)
   if not (Int.Set.mem rel
             (Context_map.dependencies_of_term ~with_red:false env !evd ctx (mkApp (tA, [| term |])) rel)) then

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -61,6 +61,7 @@ issues/issue246.v
 issues/issue249.v
 issues/issue258.v
 issues/issue286.v
+issues/issue297.v
 eqdec_error.v
 noconf_simplify.v
 le.v

--- a/test-suite/issues/issue297.v
+++ b/test-suite/issues/issue297.v
@@ -1,0 +1,5 @@
+From Equations Require Import Equations. 
+
+Goal forall P y, P y -> let n := y in n = 12 -> P n.
+  intros P y py n. simplify ?. apply py.
+Qed.


### PR DESCRIPTION
Now we ensure that solution steps (i.e. substitutions) are only applied to non-let-bound variables, so we do not lose information during simplification.