### PR TITLE
Tactic funelim apparently works better with Coq PR#12873 (which fixes a unification bug)

### DIFF
--- a/examples/AlmostFull.v
+++ b/examples/AlmostFull.v
@@ -745,7 +745,6 @@ Section SCT.
   Proof.
     intros x y. funelim (fin_union f). split. intros [].
     intros [k _]. depelim k.
-    eqns_specialize_eqs H. simpl in H.
     split. intros [Hfz|Hfs].
     now exists fz.
     specialize (H x y x y). rewrite -> H in Hfs.


### PR DESCRIPTION
I did not investigate exactly why but a call to `eqns_specialize_eqs` in `fin_union_spec` becomes useless, supposingly because `funelim` works better. Is it the expected behavior?