### PR TITLE
TacGeneric now takes a first argument telling if it comes from a quotation

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -565,7 +565,7 @@ let below_tac s =
 let tacvar_arg h =
   let ipat = Genarg.in_gen (Genarg.rawwit Tacarg.wit_intro_pattern) 
     (CAst.make @@ Tactypes.IntroNaming (Namegen.IntroIdentifier h)) in
-    TacGeneric ipat
+    TacGeneric (None, ipat)
 
 let rec_tac h h' = 
   TacArg(CAst.(make @@ TacCall(


### PR DESCRIPTION
This is to adapt to coq/coq#13028 which fixes the printing of Ltac quotations. To be merged synchronously.