### PR TITLE
Variants of depind/depelim that leaves hypothesis on the goal

### DIFF
--- a/test-suite/dep_elim.v
+++ b/test-suite/dep_elim.v
@@ -1,0 +1,25 @@
+From Equations Require Import Equations.
+
+(* Testing the [dep_elim] tactic that leaves everything
+   (that it didn't simplify) on the goal
+   so that hypothesis can be explicitly named *)
+
+Goal forall x : nat, let y := S x in let z := S y in x = x.
+Proof.
+  intros.
+  dep_elim x.
+  exact eq_refl.
+  intro n ; exact eq_refl.
+Defined.
+
+Inductive le : nat -> nat -> Prop :=
+| le_eq (n:nat) : le n n
+| le_S {n m : nat} : le n m -> le n (S m).
+
+Goal forall (x y : nat) (i : le x y), y = y.
+Proof.
+  intros.
+  dep_elim i.
+  - intro n ; exact eq_refl.
+  - intros n m lenm; exact eq_refl.
+Defined.

--- a/test-suite/dep_elim.v
+++ b/test-suite/dep_elim.v
@@ -9,7 +9,7 @@ Proof.
   intros.
   dep_elim x.
   exact eq_refl.
-  intro n ; exact eq_refl.
+  intros n IH ; exact eq_refl.
 Defined.
 
 Inductive le : nat -> nat -> Prop :=
@@ -21,5 +21,5 @@ Proof.
   intros.
   dep_elim i.
   - intro n ; exact eq_refl.
-  - intros n m lenm; exact eq_refl.
+  - intros n m lenm IH ; exact eq_refl.
 Defined.

--- a/test-suite/dep_elim.v
+++ b/test-suite/dep_elim.v
@@ -1,8 +1,32 @@
 From Equations Require Import Equations.
 
-(* Testing the [dep_elim] tactic that leaves everything
-   (that it didn't simplify) on the goal
-   so that hypothesis can be explicitly named *)
+(* Testing the [depcase] tactic that does a dependent case analysis
+   on its argument leaving the hypothesis on the goal
+   so that they can be explicitly named *)
+
+Goal forall x : nat, let y := S x in let z := S y in x = x.
+Proof.
+  intros.
+  depcase x.
+  exact eq_refl.
+  intros n ; exact eq_refl.
+Defined.
+
+Inductive le : nat -> nat -> Prop :=
+| le_eq (n:nat) : le n n
+| le_S {n m : nat} : le n m -> le n (S m).
+
+Goal forall (x y : nat) (i : le x y), y = y.
+Proof.
+  intros.
+  depcase i.
+  - intro n ; exact eq_refl.
+  - intros n m lenm ; exact eq_refl.
+Defined.
+
+(* Testing the [dep_elim] tactic that does a dependent induction
+   on its argumente leaving the hypothesis on the goal
+   so that they can be explicitly named *)
 
 Goal forall x : nat, let y := S x in let z := S y in x = x.
 Proof.

--- a/theories/CoreTactics.v
+++ b/theories/CoreTactics.v
@@ -108,6 +108,16 @@ Ltac clear_local :=
     | _ => idtac
   end.
 
+(** Provide a local zone in the context that is reverted
+    into the goal upon ternmination *)
+
+Ltac with_scoped_ctx tac :=
+  let stop := fresh "__stop" in
+  pose proof (stop := tt) ;
+  tac ;
+  revert_until stop ;
+  clear stop.
+
 (** The [do] tactic but using a Coq-side nat. *)
 
 Ltac do_nat n tac :=

--- a/theories/CoreTactics.v
+++ b/theories/CoreTactics.v
@@ -111,9 +111,11 @@ Ltac clear_local :=
 (** Provide a local zone in the context that is reverted
     into the goal upon ternmination *)
 
+Inductive scope_delimiter := MkScopeMark.
+
 Ltac with_scoped_ctx tac :=
   let stop := fresh "__stop" in
-  pose proof (stop := tt) ;
+  pose proof (stop := MkScopeMark) ;
   tac ;
   revert_until stop ;
   clear stop.

--- a/theories/HoTT/DepElim.v
+++ b/theories/HoTT/DepElim.v
@@ -590,9 +590,20 @@ Ltac do_depelim_nosimpl tac H := do_intros H ; generalize_by_eqs H ; tac H.
 
 Ltac do_depelim tac H := do_depelim_nosimpl tac H ; simpl_dep_elim; unblock_goal.
 
+Ltac do_depelim_nointro tac H :=
+  do_intros H;
+  with_scoped_ctx ltac:(generalize_by_eqs H ; tac H ; simpl_dep_elim) ;
+  unblock_goal.
+
 Ltac do_depind tac H := 
   (try intros until H) ; intro_block H ; (try simpl in H ; simplify_equations_in H) ;
   generalize_by_eqs_vars H ; tac H ; simpl_dep_elim; unblock_goal.
+
+Ltac do_depind_nointro tac H :=
+  (try intros until H) ; intro_block H ; (try simpl in H ; simplify_equations_in H) ;
+  generalize_by_eqs_vars H ;
+  with_scoped_ctx ltac:(tac H ; simpl_dep_elim);
+  unblock_goal.
 
 (** To dependent elimination on some hyp. *)
 
@@ -606,9 +617,17 @@ Ltac depelim_term c :=
 
 Ltac depelim_nosimpl id := do_depelim_nosimpl ltac:(fun hyp => do_case hyp) id.
 
+(** To dependent elimination on some hyp leaving hypothesis on goal. *)
+
+Ltac depcase id := do_depelim_nointro ltac:(fun hyp => do_case hyp) id.
+
 (** To dependent induction on some hyp. *)
 
 Ltac depind id := do_depind ltac:(fun hyp => do_ind hyp) id.
+
+(** To dependent induction on some hyp leaving hypothesis on goal. *)
+
+Ltac dep_elim id := do_depelim_nointro ltac:(fun hyp => do_ind hyp) id.
 
 (** A variant where generalized variables should be given by the user. *)
 

--- a/theories/HoTT/Tactics.v
+++ b/theories/HoTT/Tactics.v
@@ -15,7 +15,9 @@ Ltac Equations.Init.simpl_equations ::= Equations.HoTT.DepElim.simpl_equations.
 Ltac Equations.Init.simplify_equalities ::= Equations.HoTT.DepElim.simplify_dep_elim.
 
 Ltac Equations.Init.depelim H ::= dependent elimination H; cbn in *.
+Ltac Equations.Init.depcase H ::= Equations.HoTT.DepElim.depcase H.
 Ltac Equations.Init.depind H ::= Equations.HoTT.DepElim.depind H.
+Ltac Equations.Init.dep_elim H ::= Equations.HoTT.DepElim.dep_elim H.
 Ltac Equations.Init.funelim_constr H ::= funelim_constr H.
 Ltac Equations.Init.apply_funelim H ::= Equations.HoTT.FunctionalInduction.apply_funelim H.
 

--- a/theories/Init.v
+++ b/theories/Init.v
@@ -111,11 +111,14 @@ Ltac simpl_equations := fail "Equations.Init.simpl_equations has not been bound 
 (** Forward reference for Equations' [depelim] tactic, which will be defined in [DepElim]. *)
 Ltac depelim x := fail "Equations.Init.depelim has not been bound yet".
 
+(** Forward reference for Equations' [depcase] tactic, which will be defined in [DepElim]. *)
+Ltac depcase x := fail "Equations.Init.depcase has not been bound yet".
+
 (** Forward reference for Equations' [depind] tactic, which will be defined in [DepElim]. *)
 Ltac depind x := fail "Equations.Init.depind has not been bound yet".
 
 (** Forward reference for Equations' [dep_elim] tactic, which will be defined in [DepElim]. *)
-Ltac dep_elim x := fail "Equations.Init.depind has not been bound yet".
+Ltac dep_elim x := fail "Equations.Init.dep_elim has not been bound yet".
 
 (** Forward reference for Equations' [funelim] tactic, which will be defined in [FunctionalInduction]. *)
 Ltac funelim_constr x := fail "Equations.Init.funelim_constr has not been bound yet".

--- a/theories/Init.v
+++ b/theories/Init.v
@@ -114,6 +114,9 @@ Ltac depelim x := fail "Equations.Init.depelim has not been bound yet".
 (** Forward reference for Equations' [depind] tactic, which will be defined in [DepElim]. *)
 Ltac depind x := fail "Equations.Init.depind has not been bound yet".
 
+(** Forward reference for Equations' [dep_elim] tactic, which will be defined in [DepElim]. *)
+Ltac dep_elim x := fail "Equations.Init.depind has not been bound yet".
+
 (** Forward reference for Equations' [funelim] tactic, which will be defined in [FunctionalInduction]. *)
 Ltac funelim_constr x := fail "Equations.Init.funelim_constr has not been bound yet".
 

--- a/theories/Prop/DepElim.v
+++ b/theories/Prop/DepElim.v
@@ -569,13 +569,6 @@ Ltac do_intros H :=
   (try intros until H) ; (intro_block_id H || intro_block H) ;
   (try simpl in H ; simplify_equations_in H).
 
-Ltac with_scoped_ctx tac :=
-  let stop := fresh "__stop" in
-  pose proof (stop := tt) ;
-  tac ;
-  revert_until stop ;
-  clear stop.
-
 Ltac do_depelim_nosimpl tac H := do_intros H ; generalize_by_eqs H ; tac H.
 
 Ltac do_depelim tac H := do_depelim_nosimpl tac H ; simpl_dep_elim; unblock_goal.

--- a/theories/Prop/DepElim.v
+++ b/theories/Prop/DepElim.v
@@ -569,16 +569,20 @@ Ltac do_intros H :=
   (try intros until H) ; (intro_block_id H || intro_block H) ;
   (try simpl in H ; simplify_equations_in H).
 
-Ltac do_depelim_nosimpl tac H := do_intros H ; generalize_by_eqs H ; tac H.
-
-Ltac do_depelim tac H := do_depelim_nosimpl tac H ; simpl_dep_elim; unblock_goal.
-
 Ltac with_scoped_ctx tac :=
-  let stop := fresh "stop" in
+  let stop := fresh "__stop" in
   pose proof (stop := tt) ;
   tac ;
   revert_until stop ;
   clear stop.
+
+Ltac do_depelim_nosimpl tac H := do_intros H ; generalize_by_eqs H ; tac H.
+
+Ltac do_depelim tac H := do_depelim_nosimpl tac H ; simpl_dep_elim; unblock_goal.
+Ltac do_depelim_nointro tac H :=
+  do_intros H;
+  with_scoped_ctx ltac:(generalize_by_eqs H ; tac H ; simpl_dep_elim) ;
+  unblock_goal.
 
 Ltac do_depind_maybe_intro should_intro tac H :=
   (try intros until H) ; intro_block H ; (try simpl in H ; simplify_equations_in H) ;
@@ -597,6 +601,11 @@ Ltac do_depind tac H :=
 (** To dependent elimination on some hyp. *)
 
 Ltac depelim id := do_depelim ltac:(fun hyp => do_case hyp) id.
+
+(** To dependent elimination on some hyp. *)
+
+Ltac depcase id := do_depelim_nointro ltac:(fun hyp => do_case hyp) id.
+
 
 Ltac depelim_term c :=
   let H := fresh "term" in

--- a/theories/Prop/Tactics.v
+++ b/theories/Prop/Tactics.v
@@ -11,6 +11,7 @@ Require Import Equations.CoreTactics Equations.Prop.Classes Equations.Prop.DepEl
 Ltac Equations.Init.simpl_equations ::= Equations.Prop.DepElim.simpl_equations.
 Ltac Equations.Init.simplify_equalities ::= Equations.Prop.DepElim.simplify_dep_elim.
 Ltac Equations.Init.depelim H ::= Equations.Prop.DepElim.depelim H.
+Ltac Equations.Init.depcase H ::= Equations.Prop.DepElim.depcase H.
 Ltac Equations.Init.depind H ::= Equations.Prop.DepElim.depind H.
 Ltac Equations.Init.dep_elim H ::= Equations.Prop.DepElim.dep_elim H.
 Ltac Equations.Init.noconf H ::= Equations.Prop.DepElim.noconf H.

--- a/theories/Prop/Tactics.v
+++ b/theories/Prop/Tactics.v
@@ -12,6 +12,7 @@ Ltac Equations.Init.simpl_equations ::= Equations.Prop.DepElim.simpl_equations.
 Ltac Equations.Init.simplify_equalities ::= Equations.Prop.DepElim.simplify_dep_elim.
 Ltac Equations.Init.depelim H ::= Equations.Prop.DepElim.depelim H.
 Ltac Equations.Init.depind H ::= Equations.Prop.DepElim.depind H.
+Ltac Equations.Init.dep_elim H ::= Equations.Prop.DepElim.dep_elim H.
 Ltac Equations.Init.noconf H ::= Equations.Prop.DepElim.noconf H.
 Ltac Equations.Init.funelim_constr H ::= funelim_constr H.
 Ltac Equations.Init.apply_funelim H ::= Equations.Prop.FunctionalInduction.apply_funelim H.

--- a/theories/Type/DepElim.v
+++ b/theories/Type/DepElim.v
@@ -596,9 +596,20 @@ Ltac do_depelim_nosimpl tac H := do_intros H ; generalize_by_eqs H ; tac H.
 
 Ltac do_depelim tac H := do_depelim_nosimpl tac H ; simpl_dep_elim; unblock_goal.
 
+Ltac do_depelim_nointro tac H :=
+  do_intros H;
+  with_scoped_ctx ltac:(generalize_by_eqs H ; tac H ; simpl_dep_elim) ;
+  unblock_goal.
+
 Ltac do_depind tac H := 
   (try intros until H) ; intro_block H ; (try simpl in H ; simplify_equations_in H) ;
   generalize_by_eqs_vars H ; tac H ; simpl_dep_elim; unblock_goal.
+
+Ltac do_depind_nointro tac H :=
+  (try intros until H) ; intro_block H ; (try simpl in H ; simplify_equations_in H) ;
+  generalize_by_eqs_vars H ;
+  with_scoped_ctx ltac:(tac H ; simpl_dep_elim);
+  unblock_goal.
 
 (** To dependent elimination on some hyp. *)
 
@@ -612,9 +623,17 @@ Ltac depelim_term c :=
 
 Ltac depelim_nosimpl id := do_depelim_nosimpl ltac:(fun hyp => do_case hyp) id.
 
+(** To dependent elimination on some hyp leaving hypothesis on goal. *)
+
+Ltac depcase id := do_depelim_nointro ltac:(fun hyp => do_case hyp) id.
+
 (** To dependent induction on some hyp. *)
 
 Ltac depind id := do_depind ltac:(fun hyp => do_ind hyp) id.
+
+(** To dependent induction on some hyp leaving hypothesis on goal. *)
+
+Ltac dep_elim id := do_depelim_nointro ltac:(fun hyp => do_ind hyp) id.
 
 (** A variant where generalized variables should be given by the user. *)
 

--- a/theories/Type/Tactics.v
+++ b/theories/Type/Tactics.v
@@ -14,7 +14,9 @@ Ltac Equations.Init.simpl_equations ::= Equations.Type.DepElim.simpl_equations.
 Ltac Equations.Init.simplify_equalities ::= Equations.Type.DepElim.simplify_dep_elim.
 
 Ltac Equations.Init.depelim H ::= dependent elimination H; cbn in *.
+Ltac Equations.Init.depcase H ::= Equations.Type.DepElim.depcase H.
 Ltac Equations.Init.depind H ::= Equations.Type.DepElim.depind H.
+Ltac Equations.Init.dep_elim H ::= Equations.Type.DepElim.dep_elim H.
 Ltac Equations.Init.funelim_constr H ::= funelim_constr H.
 Ltac Equations.Init.apply_funelim H ::= Equations.Type.FunctionalInduction.apply_funelim H.
 


### PR DESCRIPTION
This PR tries to provide a variant `dep_elim` of `depind` that leaves all the non-simplified hypothesis in the goal.

It uses elim instead of induction (but that might not be a useful change since we anyway mark the context and revert everything before it in the simplification phase).

TODO:
- [ ] maybe find a less conflicting name than `dep_elim`
- [x] implement the tactic for HoTT and Type (and not only for Prop)
- [x] provide a similar tactic for `depelim`