### PR TITLE
Adapt to Coq PR #13143: Pp.h does not take a (dummy) integer anymore.

### DIFF
--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -215,7 +215,7 @@ let pr_splitting env sigma ?(verbose=false) split =
                 pr_context_map env sigma lhs ++ spc ()) ++
        (Array.fold_left
           (fun acc so -> acc ++
-                         h 2 (match so with
+                         hov 2 (match so with
                              | None -> str "*impossible case*" ++ Pp.fnl ()
                              | Some s -> aux s))
           (mt ()) cs))


### PR DESCRIPTION
PR coq/coq#13143 proposes to clarify that the integer argument of `Pp.h` boxes is irrelevant. There was one use of `Pp.h` in Coq-Equations which called it with a value 2. So, suspectingly, the intent was to really indent, so I moved the h box to hov box. Please check though.

If the hov is ok, it is compatible and can be merged as soon as now.