### PR TITLE
Remove references to Omega/omega for Coq PR 13741 ("Remove omega tactic")

### DIFF
--- a/examples/nm.v
+++ b/examples/nm.v
@@ -10,8 +10,6 @@ Equations exp_size : exp -> nat :=
   exp_size (If e1 e2 e3) := exp_size e1 * (1 + exp_size e2 + exp_size e3).
 Transparent exp_size.
 
-Require Import Omega.
-
 Lemma exp_size_pos (x : exp) : (0 < exp_size x)%nat.
 Proof. funelim (exp_size x); auto; try lia. apply Nat.mul_pos_pos; auto. lia. Qed.
 Hint Resolve exp_size_pos : core.

--- a/test-suite/cfold.v
+++ b/test-suite/cfold.v
@@ -2,7 +2,7 @@
    Proof size is now constant instead of quadratic.,
    but program is as straightforward as in Agda. *)
 
-Require Import Arith Omega.
+Require Import Arith.
 From Equations Require Import Equations.
 Require Import Coq.Bool.Bool.
 

--- a/test-suite/issues/issue328.v
+++ b/test-suite/issues/issue328.v
@@ -1,5 +1,4 @@
 Set Implicit Arguments.
-From Coq Require Import Omega.
 From Equations Require Import Equations.
 
 Parameter A : Type.
@@ -15,8 +14,8 @@ Equations? fromList (l : list A) : length l > 0 -> nonEmpty A :=
   fromList (cons x (cons y l))  _ := consNE x (fromList (cons y l) _)
 }.
 Proof.
-  - exfalso. abstract omega.
-  - abstract omega.
+  - exfalso. abstract lia.
+  - abstract lia.
 Defined.
 (* Error: <in exception printer>:<original exception:Anomaly "Uncaught exception Not_found." *)
 (* Please report at http://coq.inria.fr/bugs/. *)

--- a/test-suite/issues/issue95_1.v
+++ b/test-suite/issues/issue95_1.v
@@ -1,5 +1,4 @@
 Require Import Equations.Equations.
-Require Import Omega.
 
 Inductive type: Set :=
   | T_bool: type

--- a/test-suite/terms.v
+++ b/test-suite/terms.v
@@ -1,5 +1,4 @@
 From Equations Require Import Equations Fin DepElimDec.
-Require Import Omega.
 
 Inductive term :=
 | Var : nat -> term

--- a/test-suite/wfnocycle.v
+++ b/test-suite/wfnocycle.v
@@ -1,6 +1,6 @@
 Set Warnings "-notation-overridden".
 From Equations Require Import Equations.
-Require Import Omega Utf8 Arith Compare_dec List Lia.
+Require Import Utf8 Arith Compare_dec List Lia.
 Require Import Relation_Operators.
 Arguments clos_trans [A].
 Import Sigma_Notations.


### PR DESCRIPTION
Is this all in order?

https://github.com/coq/coq/pull/13741