### PR TITLE
Fix issue #329

### DIFF
--- a/src/context_map.mli
+++ b/src/context_map.mli
@@ -140,7 +140,7 @@ val strengthen :
   rel_context ->
   Int.Set.elt ->
   constr ->
-  context_map * (int * int) list
+  context_map * context_map
 
 (* Return a substitution and its inverse. *)
 (* For more flexibility, [rels] is a set of indices which are to be

--- a/src/splitting.mli
+++ b/src/splitting.mli
@@ -74,6 +74,7 @@ and refined_node =
     refined_arg : int * int; (* Index counting lets or not *)
     refined_path : path;
     refined_term : EConstr.t;
+    refined_filter : int list option;
     refined_args : constr list;
     refined_revctx : context_map;
     refined_newprob : context_map;
@@ -102,6 +103,9 @@ val program_rec : program -> program_rec_info option
 
 val pr_path : Evd.evar_map -> path -> Pp.t
 val eq_path : path -> path -> bool
+
+val pr_splitting_rhs : ?verbose:bool -> env -> env (* With wheres *) -> Evd.evar_map -> context_map -> splitting_rhs -> 
+    EConstr.t -> Pp.t
 
 val pr_splitting : env -> Evd.evar_map -> ?verbose:bool -> splitting -> Pp.t
 val ppsplit : splitting -> unit

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -65,6 +65,7 @@ issues/issue286.v
 issues/issue297.v
 issues/issue306.v
 issues/issue328.v
+issues/issue329.v
 issues/issue338.v
 issues/issue346.v
 issues/issue349.v

--- a/test-suite/issues/issue329.v
+++ b/test-suite/issues/issue329.v
@@ -1,0 +1,24 @@
+Require Import List ssreflect.
+Require Import Equations.Equations.
+Import ListNotations.
+
+Equations ok_clause (e : nat -> option bool) (xs : list nat) : bool :=
+  ok_clause e xs => ok_clause' e xs
+    where
+      ok_clause' (p : nat -> option bool) (l : list nat) : bool by struct l :=
+      ok_clause' _ [] => true;
+      ok_clause' p (x::l) with p x =>
+      { | Some _ => ok_clause' p l;
+        | _ => false }.
+
+Lemma ok_clause_test p : ok_clause p [] = true.
+Proof.
+  now simp ok_clause.
+Qed.
+
+Lemma ok_clause_test' p cl : ok_clause p cl = false -> exists y, In y cl /\ p y = None.
+Proof.
+  apply (ok_clause_elim (fun e xs call => call = false -> exists y, In y xs /\ e y = None)
+    (fun _ _ e xs call => call = false -> exists y, In y xs /\ e y = None)).
+  all:try solve [cbn; try discriminate; firstorder eauto].
+Qed.


### PR DESCRIPTION
Use a better strengthening function avoiding to strenghten over a recursive function, which in turn would make the guardness checker bail. Also cleans up and fixes a little bit the generation of equations/graph constructors for definitions involving with which was working only in the most simple cases of strengthenings.

Closes #329 