### PR TITLE
Fix issue #390

### DIFF
--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -74,7 +74,7 @@ let autorewrites b =
 
 exception RewriteSucceeded of EConstr.t
 
-let rewrite_try_change tac = 
+let _rewrite_try_change tac = 
   Proofview.Goal.enter (fun gl ->
     let concl = Proofview.Goal.concl gl in
     Proofview.tclORELSE 
@@ -83,6 +83,9 @@ let rewrite_try_change tac =
           let env = Proofview.Goal.env gl in
           let sigma = Proofview.Goal.sigma gl in
           let concl' = Proofview.Goal.concl gl in
+          Feedback.msg_debug (str"Converting " ++
+          Printer.pr_econstr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) concl ++ str " and " ++
+          Printer.pr_econstr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) concl');
           match Reductionops.infer_conv ~pb:Reduction.CONV env sigma concl concl' with
           | Some _ -> Proofview.tclZERO (RewriteSucceeded concl')
           | None -> Proofview.tclUNIT ())))
@@ -103,14 +106,15 @@ let autorewrite_one b =
          (if r.Autorewrite.rew_l2r then Equality.rewriteLR else Equality.rewriteRL)
        in
        Proofview.tclOR
-         (if !debug then
+         (* (if !debug then
             (Proofview.Goal.enter
                begin fun gl -> 
                 let concl = Proofview.Goal.concl gl in
                 Feedback.msg_debug (str"Trying " ++ pr_global global ++ str " on " ++
                 Printer.pr_econstr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) concl);
-                rewrite_try_change tac end)
-          else tac)
+                observe_new "rewrite_try_change" (rewrite_try_change tac) end)
+          else  *)
+            tac
          (fun e -> if !debug then Feedback.msg_debug (str"failed"); aux rules)
   in aux rew_rules
 

--- a/test-suite/issues/issue390.v
+++ b/test-suite/issues/issue390.v
@@ -1,0 +1,18 @@
+From Coq Require Import Lia NArith.NArith Program.Tactics.
+From Equations Require Export Equations.
+Ltac hidebody H ::= idtac.
+
+Import Pos N.
+
+Open Scope N_scope.
+
+Instance lt_well_founded : WellFounded lt := Acc_intro_generator 100 lt_wf_0.
+
+(* Ltac Init.hidebody H ::= idtac. *)
+
+Equations? f (a : N) : N by wf a lt :=
+  f N0 := 0;
+  f (pos n) := succ (f (pred_N n)).
+Proof. lia. Qed.
+
+Compute f 42.

--- a/theories/HoTT/Subterm.v
+++ b/theories/HoTT/Subterm.v
@@ -64,10 +64,10 @@ Ltac unfold_FixWf :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
      unshelve erewrite (@FixWf_unfold_step A R WF P f x _ step idpath);
      [red; intros; simp_sigmas; red_one_eq (* Extensionality proof *)
-     |hidebody step; try red_eq_lhs (* Unfold the functional *)]
+     |try red_eq_lhs (* Unfold the functional *)]
   end.
 
 Ltac unfold_recursor := unfold_FixWf.
@@ -96,10 +96,10 @@ Ltac unfold_FixWf_ext :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
     eapply concat;
     [exact (@FixWf_unfold_ext_step (_ : Funext) A R WF P f x step idpath) |
-     hidebody step; try red_eq_lhs (* Unfold the functional *)]
+     try red_eq_lhs (* Unfold the functional *)]
   end.
 
 Ltac unfold_recursor_ext := unfold_FixWf_ext.

--- a/theories/Init.v
+++ b/theories/Init.v
@@ -61,6 +61,9 @@ Definition hidebody {A : Type} {a : A} := a.
 Register hidebody as equations.internal.hidebody.
 Extraction Inline hidebody.
 
+(** Beware, if [b] can result in a large computation, this can lead to 
+  stack overflow while converting [b] with [hidebody b]. Not used 
+  in Equations's tactics. *)
 Ltac hidebody H :=
   match goal with
     [ H := ?b |- _ ] => change (@hidebody _ b) in (value of H)

--- a/theories/Prop/Subterm.v
+++ b/theories/Prop/Subterm.v
@@ -57,10 +57,10 @@ Ltac unfold_FixWf :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
      unshelve erewrite (@FixWf_unfold_step A R WF P f x _ step);
      [red; intros; simp_sigmas; red_one_eq (* Extensionality proof *)
-     |hidebody step; red_eq_lhs (* Unfold the functional *)
+     |red_eq_lhs (* Unfold the functional *)
      |reflexivity]
   end.
 
@@ -100,9 +100,9 @@ Ltac unfold_FixWf_ext :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
     rewrite (@FixWf_unfold_ext_step A R WF P f x step);
-    [hidebody step; try red_eq_lhs (* Unfold the functional *)
+    [try red_eq_lhs (* Unfold the functional *)
     |reflexivity]
   end.
 

--- a/theories/Type/Subterm.v
+++ b/theories/Type/Subterm.v
@@ -60,10 +60,10 @@ Ltac unfold_FixWf :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
      unshelve erewrite (@FixWf_unfold_step A R WF P f x _ step);
      [red; intros; simp_sigmas; red_one_eq (* Extensionality proof *)
-     |hidebody step; red_eq_lhs (* Unfold the functional *)
+     |red_eq_lhs (* Unfold the functional *)
      |reflexivity]
   end.
 
@@ -94,9 +94,9 @@ Ltac unfold_FixWf_ext :=
   match goal with
     |- context [ @FixWf ?A ?R ?WF ?P ?f ?x ] =>
     let step := fresh in
-    set(step := fun y (_ : R y x) => @FixWf A R WF P f y) in *;
+    set(step := @hidebody _ (fun y (_ : R y x) => @FixWf A R WF P f y)) in *;
     rewrite (@FixWf_unfold_ext_step A R WF P f x step);
-    [hidebody step; try red_eq_lhs (* Unfold the functional *)|reflexivity]
+    [try red_eq_lhs (* Unfold the functional *)|reflexivity]
   end.
 
 Ltac unfold_recursor_ext := unfold_FixWf_ext.


### PR DESCRIPTION
Bad behavior of the `hidebody` tactic in presence of unfoldable well-founded proofs in the body to hide, which can lead to stack overflow during conversion. We can just avoid conversion altogether. 