### PR TITLE
Add ocamlfind as a build dependency

### DIFF
--- a/coq-equations.opam
+++ b/coq-equations.opam
@@ -32,6 +32,7 @@ run-test: [
 ]
 depends: [
   "coq" {= "dev"}
+  "ocamlfind" {build}
 ]
 #depopts: [
 #  "coq-hott" {= "8.13"}


### PR DESCRIPTION
This pull-request adds `ocamlfind` as a build dependency. Indeed, even if `ocamlfind` should already be installed by Coq, there are some rare cases where it seems this is not the case because `ocamlbuild` is a `build` dependency and can be removed after install. Here is a log where this seemingly happens (this may be something else though). In any case, the generated Makefile seems to use `ocamlfind` to find the OCaml binaries.
```
Command
    opam list; echo; ulimit -Sv 4000000; timeout 4h opam install -y --deps-only coq-hydra-battles.0.4 coq.8.12.0
Return code
    7936
Duration
    9 m 27 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    coq                 8.12.0      Formal proof management system
    num                 1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml               4.07.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.07.1      Official release 4.07.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    The following actions will be performed:
      - install   coq-equations            1.2.4+8.12
      - install   conf-m4                  1              [required by ocamlfind]
      - install   ocaml-secondary-compiler 4.08.1-1
      - downgrade ocamlfind                1.9.1 to 1.8.1
      - install   ocamlfind-secondary      1.8.1
      - install   dune                     2.8.5
    ===== 5 to install | 1 to downgrade =====
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    [coq-equations.1.2.4+8.12] downloaded from https://github.com/mattam82/Coq-Equations/archive/v1.2.4-8.12.tar.gz
    [dune.2.8.5] downloaded from cache at https://opam.ocaml.org/cache
    [ocamlfind.1.8.1] downloaded from cache at https://opam.ocaml.org/cache
    [ocamlfind-secondary.1.8.1] found in cache
    [ocaml-secondary-compiler.4.08.1-1] downloaded from cache at https://opam.ocaml.org/cache
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    [WARNING] While removing ocamlfind.1.9.1: not removing files that changed since:
                - man/man5/site-lib.5
                - man/man5/findlib.conf.5
                - man/man5/META.5
                - man/man1/ocamlfind.1
                - lib/unix/META
                - lib/toplevel/topfind
                - lib/threads/META
                - lib/str/META
                - lib/stdlib/META
                - lib/raw_spacetime/META
                - lib/ocamldoc/META
                - lib/ocaml/topfind
                - lib/graphics/META
                - lib/findlib/topfind.mli
                - lib/findlib/topfind.cmi
                - lib/findlib/fl_package_base.mli
                - lib/findlib/fl_package_base.cmi
                - lib/findlib/fl_metatoken.cmi
                - lib/findlib/fl_metascanner.mli
                - lib/findlib/fl_metascanner.cmi
                - lib/findlib/fl_dynload.mli
                - lib/findlib/fl_dynload.cmi
                - lib/findlib/findlib_top.cmxs
                - lib/findlib/findlib_top.cmxa
                - lib/findlib/findlib_top.cma
                - lib/findlib/findlib_top.a
                - lib/findlib/findlib_dynload.cmxs
                - lib/findlib/findlib_dynload.cmxa
                - lib/findlib/findlib_dynload.cma
                - lib/findlib/findlib_dynload.a
                - lib/findlib/findlib.mli
                - lib/findlib/findlib.cmxs
                - lib/findlib/findlib.cmxa
                - lib/findlib/findlib.cmi
                - lib/findlib/findlib.cma
                - lib/findlib/findlib.a
                - lib/findlib/Makefile.packages
                - lib/findlib/Makefile.config
                - lib/findlib/META
                - lib/findlib.conf
                - lib/dynlink/META
                - lib/compiler-libs/META
                - lib/bytes/META
                - lib/bigarray/META
    [NOTE] While removing ocamlfind.1.9.1: not removing non-empty directories:
             - lib/unix
             - lib/threads
             - lib/str
             - lib/stdlib
             - lib/raw_spacetime
             - lib/ocamldoc
             - lib/graphics
             - lib/findlib
             - lib/dynlink
             - lib/compiler-libs
             - lib/bytes
             - lib/bigarray
    -> removed   ocamlfind.1.9.1
    -> installed conf-m4.1
    [ERROR] The compilation of coq-equations failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    -> installed ocamlfind.1.8.1
    -> installed ocaml-secondary-compiler.4.08.1-1
    -> installed ocamlfind-secondary.1.8.1
    -> installed dune.2.8.5
    #=== ERROR while compiling coq-equations.1.2.4+8.12 ===========================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-equations.1.2.4+8.12
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-equations-30734-d8393c.env
    # output-file          ~/.opam/log/coq-equations-30734-d8393c.out
    ### output ###
    # [...]
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # CAMLOPT -c  src/equations_common.ml
    # CAMLOPT -c  src/ederive.ml
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # make[1]: *** [Makefile.coq:663: src/equations_common.cmx] Error 127
    # make[1]: *** Waiting for unfinished jobs....
    # CAMLOPT -c  src/syntax.ml
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # make[1]: *** [Makefile.coq:664: src/ederive.cmx] Error 127
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # make[1]: *** [Makefile.coq:664: src/syntax.cmx] Error 127
    # make: *** [Makefile.coq:339: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-equations 1.2.4+8.12
    +- 
    +- The following changes have been performed
    | - downgrade ocamlfind                1.9.1 to 1.8.1
    | - install   conf-m4                  1
    | - install   dune                     2.8.5
    | - install   ocaml-secondary-compiler 4.08.1-1
    | - install   ocamlfind-secondary      1.8.1
    +- 
    # Run eval $(opam env) to update the current shell environment
    The former state can be restored with:
        opam switch import "/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/backup/state-20210629143103.export"
```