### PR TITLE
Adapting Equations to the use of None for dummy locations

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -733,7 +733,7 @@ let interp_arity env evd ~poly ~is_rec ~with_evars notations (((loc,i),udecl,rec
   let (arity, impls') =
     let ty = match t with
       | Some ty -> ty
-      | None -> CAst.make ~loc (Constrexpr.CHole (None, Namegen.IntroAnonymous, None))
+      | None -> CAst.make ?loc (Constrexpr.CHole (None, Namegen.IntroAnonymous, None))
     in
     Equations_common.evd_comb1 (interp_type_evars_impls env' ?impls:None) evd ty
   in
@@ -761,7 +761,7 @@ let interp_arity env evd ~poly ~is_rec ~with_evars notations (((loc,i),udecl,rec
             let k, _, _ = lookup_rel_id (snd lid) sign in
             Some (Structural (interp_reca rec_annot (Some (List.length sign - k, Some lid))))
           with Not_found ->
-            user_err_loc (Some (fst lid), "struct_index",
+            user_err_loc (fst lid, "struct_index",
                           Pp.(str"No argument named " ++ Id.print (snd lid) ++ str" found")))
        | None -> Some (Structural (interp_reca rec_annot None)))
     | Some (WellFounded (c, r)) -> Some (WellFounded (c, r))
@@ -1243,7 +1243,7 @@ let rec covering_aux env evars p data prev (clauses : (pre_clause * (int * int))
       Some (List.rev prev @ clauses, (* Split (prob, i, ty, s)) *)
             Compute (prob, [], ty, REmpty (i, s)))
     | None ->
-      user_err_loc (Some p.program_loc, "deppat",
+      user_err_loc (p.program_loc, "deppat",
         (str "Non-exhaustive pattern-matching, no clause found for:" ++ fnl () ++
          pr_problem p env !evars prob))
 
@@ -1254,7 +1254,7 @@ and interp_clause env evars p data prev clauses' path (ctx,pats,ctx' as prob)
   let get_var loc i s =
     match assoc i s with
     | PRel i -> i
-    | _ -> user_err_loc (Some loc, "equations", str"Unbound variable " ++ Id.print i)
+    | _ -> user_err_loc (loc, "equations", str"Unbound variable " ++ Id.print i)
   in
   let () = (* Check innaccessibles are correct *)
     let check_uinnac (user, t) =
@@ -1321,7 +1321,7 @@ and interp_clause env evars p data prev clauses' path (ctx,pats,ctx' as prob)
 
   | Empty (loc,i) ->
     (match prove_empty (env, evars) (pi1 prob) (get_var loc i s) with
-     | None -> user_err_loc (Some loc, "covering", str"Cannot show that " ++ Id.print i ++ str"'s type is empty")
+     | None -> user_err_loc (loc, "covering", str"Cannot show that " ++ Id.print i ++ str"'s type is empty")
      | Some (i, ctx, s) ->
        Some (Compute (prob, [], ty, REmpty (i, s))))
 
@@ -1566,7 +1566,7 @@ and interp_wheres env0 ctx evars path data s lets
         Lazy.from_val (w' program), program.program_term
       | None ->
         let relty = Syntax.program_type p in
-        let src = (Some loc, Evar_kinds.(QuestionMark {
+        let src = (loc, Evar_kinds.(QuestionMark {
             qm_obligation=Define false;
             qm_name=Name id;
             qm_record_field=None;

--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -416,7 +416,7 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
         | Some (Covering.Splitted (_, newctx, brs)) ->
             let brs = Option.List.flatten (Array.to_list brs) in
             let clauses_lhs = List.map Context_map.context_map_to_lhs brs in
-            let clauses = List.map (fun lhs -> (Some default_loc, lhs, Some rhs)) clauses_lhs in
+            let clauses = List.map (fun lhs -> (default_loc, lhs, Some rhs)) clauses_lhs in
               Proofview.tclUNIT clauses
         end
     | Some patterns ->

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -208,7 +208,7 @@ let interp_tactic = function
   | None -> !Declare.Obls.default_tactic
 
 let equations ~pm ~poly ~program_mode ?tactic opts eqs nt =
-  List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ~loc i) false "def") eqs;
+  List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ?loc i) false "def") eqs;
   let tactic = interp_tactic tactic in
   let pm, pstate =
     define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof:false opts eqs nt in
@@ -218,7 +218,7 @@ let equations ~pm ~poly ~program_mode ?tactic opts eqs nt =
     CErrors.anomaly Pp.(str"Equation.equations leaving a proof open")
 
 let equations_interactive ~pm ~poly ~program_mode ?tactic opts eqs nt =
-  List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ~loc i) false "def") eqs;
+  List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ?loc i) false "def") eqs;
   let tactic = interp_tactic tactic in
   let pm, lemma = define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof:true opts eqs nt in
   match lemma with

--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -139,7 +139,7 @@ let pr_lident _ _ _ (loc, id) = Id.print id
 
 ARGUMENT EXTEND lident
 PRINTED BY { pr_lident }
-| [ ident(i) ] -> { (loc, i) }
+| [ ident(i) ] -> { (Some loc, i) }
 END
 
 {
@@ -295,7 +295,7 @@ GRAMMAR EXTEND Gram
 
     
   identloc :
-   [ [ id = ident -> { (loc, id) } ] ] ;
+   [ [ id = ident -> { (Some loc, id) } ] ] ;
 
   patterns: 
    [ [ pat = lconstr ; sep = [ "|" -> { () } | "," -> { () } ]; pats = patterns -> { pat :: pats } 
@@ -500,9 +500,9 @@ ARGUMENT EXTEND elim_patterns
 END
 
 TACTIC EXTEND dependent_elimination
-| [ "dependent" "elimination" ident(id) ] -> { Depelim.dependent_elim_tac (Loc.make_loc (0, 0), id) }
+| [ "dependent" "elimination" ident(id) ] -> { Depelim.dependent_elim_tac (None, id) }
 | [ "dependent" "elimination" ident(id) "as" elim_patterns(l) ] ->
-   { Depelim.dependent_elim_tac ~patterns:l (Loc.make_loc (0, 0), id) (* FIXME *) }
+   { Depelim.dependent_elim_tac ~patterns:l (None, id) (* FIXME *) }
 END
 
 (* Subterm *)

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -238,7 +238,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
       notations = []
     }
   in
-  let p = Syntax.{program_loc = Loc.make_loc (0,0);
+  let p = Syntax.{program_loc = None;
                   program_id = id;
                   program_impls = []; program_implicits = [];
                   program_rec = None;
@@ -252,7 +252,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
       env evd p data clauses [] ctxmap [] s in
   let hook ~pm _ p terminfo =
     (* let _proginfo =
-     *   Syntax.{ program_loc = Loc.make_loc (0,0); program_id = id;
+     *   Syntax.{ program_loc = None; program_id = id;
      *            program_orig_type; program_sort;
      *            program_sign = fullbinders;
      *            program_arity = s;

--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -460,7 +460,7 @@ let aux_ind_fun info chop nested unfp unfids p =
                     filter (fun x -> not (hidden x)) (filter_def_pats lhs), var
                 in
                 let id = find_splitting_var (project gl) pats var pats' in
-                to82 (Depelim.dependent_elim_tac (Loc.make_loc (0,0), id)) gl
+                to82 (Depelim.dependent_elim_tac (None, id)) gl
               | _ -> to82 (tclFAIL 0 (str"Unexpected goal in functional induction proof")) gl)
            (fun i gl ->
               let split = nth splits (pred i) in
@@ -888,7 +888,7 @@ let headcst sigma f =
   else assert false
 
 let prove_unfolding_lemma info where_map f_cst funf_cst p unfp gl =
-  let depelim h = Depelim.dependent_elim_tac (Loc.make_loc (0,0), h) (* depelim_tac h *) in
+  let depelim h = Depelim.dependent_elim_tac (None, h) (* depelim_tac h *) in
   let helpercsts = List.map (fun (cst, i) -> cst) info.helpers_info in
   let opacify, transp = simpl_of ((destConstRef (Lazy.force coq_hidebody), Conv_oracle.transparent)
     :: List.map (fun x -> x, Conv_oracle.Expand) (f_cst :: funf_cst :: helpercsts)) in

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -458,7 +458,7 @@ let define_mutual_nested env evd get_prog progs =
       Pretyping.search_guard env (Array.to_list possible_indexes)
           (names, tys, bodies)
     with e -> 
-      user_err_loc (Some (fst (List.hd progs)).program_loc, "define", CErrors.print e)
+      user_err_loc ((fst (List.hd progs)).program_loc, "define", CErrors.print e)
   in
   let declare_fix_fns i (p,prog) =
     let newidx = indexes.(i) in
@@ -763,7 +763,7 @@ let make_programs env evd flags ?(define_constants=false) programs =
     let terms =
       List.map (function
           | Mutual (p, prob, r, s', after, term) -> (p, (prob, r, s', after, lift 1 term))
-          | Single (p, _, _, _, _) -> user_err_loc (Some p.program_loc, "make_programs",
+          | Single (p, _, _, _, _) -> user_err_loc (p.program_loc, "make_programs",
                                              str "Cannot define " ++ Names.Id.print p.program_id ++
                                              str " mutually with other programs "))
         sterms
@@ -1084,13 +1084,13 @@ let solve_equations_obligations ~pm flags recids loc i sigma hook =
   let prf = Declare.Proof.get lemma in
   let pm, lemma = if Proof.is_done prf then
     if flags.open_proof then 
-      (warn_complete ~loc i; pm, Some lemma)
+      (warn_complete ?loc i; pm, Some lemma)
     else
       (let pm, _ = Declare.Proof.save ~pm ~proof:lemma ~opaque:Vernacexpr.Transparent ~idopt:None in
        pm, None)
   else if flags.open_proof then pm, Some lemma
   else
-    user_err_loc (Some loc, "define", str"Equations definition generated subgoals that " ++
+    user_err_loc (loc, "define", str"Equations definition generated subgoals that " ++
                                   str "could not be solved automatically. Use the \"Equations?\" command to" ++
                                   str " refine them interactively.")
   in
@@ -1293,7 +1293,7 @@ let define_programs (type a) ~pm env evd udecl is_recursive fixprots flags ?(unf
         (), pm, None
     else
       if flags.open_proof then 
-        begin warn_complete ~loc id;
+        begin warn_complete ?loc id;
           let pm, lemma =
             solve_equations_obligations ~pm flags recids loc id !evd (all_hook hook) in
           (), pm, lemma

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -12,7 +12,7 @@ open Evd
 open Names
 open Equations_common
 
-type 'a with_loc = Loc.t * 'a
+type 'a with_loc = Loc.t option * 'a
 
 (** User-level patterns *)
 type provenance = 
@@ -148,7 +148,7 @@ type program_rec_info =
   (rec_annot, wf_rec_info) by_annot
 
 type program_info = {
-  program_loc : Loc.t;
+  program_loc : Loc.t option;
   program_id : Id.t;
   program_orig_type : EConstr.t; (* The original type *)
   program_sort : Univ.Universe.t; (* The sort of this type *)


### PR DESCRIPTION
This PR uses the Coq-recommended `None` for "dummy" locations rather than `(0,0)` which is confusing (see coq/coq#14618 for a discussion).