### PR TITLE
Adapt w.r.t. coq/coq#14697.

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -1037,7 +1037,8 @@ let of_evar_map x = x
 let evar_absorb_arguments = Evardefine.evar_absorb_arguments
 
 let hintdb_set_transparency cst b db =
-  Hints.add_hints ~locality:Goptions.OptGlobal [db] 
+  let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
+  Hints.add_hints ~locality [db] 
     (Hints.HintsTransparencyEntry (Hints.HintsReferences [Tacred.EvalConstRef cst], b))
 
 (* Call the really unsafe is_global test, we use this on evar-open terms too *)

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -708,10 +708,11 @@ let declare_wf_obligations s info =
      Hints.PathAny, subst_protos s gr)
   in
   let dbname = Principles_proofs.wf_obligations_base info in
+  let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
   Hints.create_hint_db false dbname TransparentState.full false;
   List.iter (fun obl ->
       let hint = make_resolve (GlobRef.ConstRef obl) in
-      try Hints.add_hints ~locality:Goptions.OptGlobal
+      try Hints.add_hints ~locality
             [dbname]
             (Hints.HintsResolveEntry [hint])
       with CErrors.UserError (s, msg) (* Cannot be used as a hint *) ->
@@ -1308,7 +1309,8 @@ let declare_funind ~pm info alias env evd is_rec protos progs
   let app = applist (f, args) in
   let hookind { Declare.Hook.S.uctx; scope; dref; _ } pm =
     let env = Global.env () in (* refresh *)
-    Hints.add_hints ~locality:Goptions.OptGlobal [info.term_info.base_id]
+    let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
+    Hints.add_hints ~locality [info.term_info.base_id]
                     (Hints.HintsImmediateEntry [Hints.PathAny, Hints.hint_globref dref]);
     let pm =
       try declare_funelim ~pm info.term_info env evd is_rec protos progs
@@ -1674,12 +1676,13 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
         mkIndU ((kn,0), EInstance.make (Univ.UContext.instance uctx))
       | Monomorphic_entry _ -> mkInd (kn,0)
     in
+    let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
     let _ =
       List.iteri (fun i ind ->
         let constrs =
           CList.map_i (fun j _ -> Hints.empty_hint_info, true, Hints.PathAny,
             Hints.hint_globref (GlobRef.ConstructRef ((kn,i),j))) 1 ind.Entries.mind_entry_lc in
-          Hints.add_hints ~locality:Goptions.OptGlobal [info.base_id] (Hints.HintsResolveEntry constrs))
+          Hints.add_hints ~locality [info.base_id] (Hints.HintsResolveEntry constrs))
         inds
     in
     let info = { term_info = info; pathmap = !fnind_map; wheremap } in
@@ -1710,14 +1713,15 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
               (*                   impossible_call_tac (GlobRef.ConstRef cst))) *));
         eqns.(j).(pred i) <- true;
         if CArray.for_all (CArray.for_all (fun x -> x)) eqns then (
+          let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
           (* From now on, we don't need the reduction behavior of the constant anymore *)
-          Hints.(add_hints ~locality:Goptions.OptGlobal [info.base_id]
+          Hints.(add_hints ~locality [info.base_id]
             (HintsTransparencyEntry (HintsReferences [Tacred.EvalConstRef ocst], false)));
           Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false;
           (match alias with
            | Some ((f, _), _, _) ->
               let cst' = fst (destConst !evd f) in
-              Hints.(add_hints ~locality:Goptions.OptGlobal [info.base_id]
+              Hints.(add_hints ~locality [info.base_id]
                 (HintsTransparencyEntry (HintsReferences [Tacred.EvalConstRef cst'], false)));
               Global.set_strategy (ConstKey cst') Conv_oracle.Opaque
            | None -> ());

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -1213,7 +1213,7 @@ let simplify_evars evars t =
 
 let unfold_entry cst = Hints.HintsUnfoldEntry [Tacred.EvalConstRef cst]
 let add_hint local i cst =
-  let locality = if local then Goptions.OptLocal else Goptions.OptGlobal in
+  let locality = if local || Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
   Hints.add_hints ~locality [Id.to_string i] (unfold_entry cst)
 
 type 'a hook =

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -175,7 +175,8 @@ let derive_subterm ~pm env sigma ~poly (ind, u as indu) =
           Hints.hint_globref (GlobRef.ConstructRef ((k,i),j))) 1 entry.mind_entry_lc)
         0 inds
     in
-    let () = Hints.add_hints ~locality:Goptions.OptGlobal [subterm_relation_base]
+    let locality = if Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
+    let () = Hints.add_hints ~locality [subterm_relation_base]
                              (Hints.HintsResolveEntry (List.concat constrhints)) in
     (* Proof of Well-foundedness *)
     let relid = add_suffix (Nametab.basename_of_global (GlobRef.IndRef ind))
@@ -230,7 +231,7 @@ let derive_subterm ~pm env sigma ~poly (ind, u as indu) =
         evm := evm';
         (* Impargs.declare_manual_implicits false (ConstRef cst) ~enriching:false *)
         (* 	(list_map_i (fun i _ -> ExplByPos (i, None), (true, true, true)) 1 parambinders); *)
-        Hints.add_hints ~locality:Goptions.OptGlobal [subterm_relation_base]
+        Hints.add_hints ~locality [subterm_relation_base]
                         (Hints.HintsUnfoldEntry [Tacred.EvalConstRef kn]);
         mkApp (cst, extended_rel_vect 0 parambinders)
       in


### PR DESCRIPTION
Should be backwards compatible. Equations was abusing the fact that for hints defined inside sections, the global attribute was simply ignored.