### PR TITLE
Adapting to Coq PR #14692: UContext now includes the names by default

### DIFF
--- a/src/principles.ml
+++ b/src/principles.ml
@@ -1670,7 +1670,7 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
     let ind =
       let open Entries in
       match uctx with
-      | Polymorphic_entry (_, uctx) ->
+      | Polymorphic_entry uctx ->
         mkIndU ((kn,0), EInstance.make (Univ.UContext.instance uctx))
       | Monomorphic_entry _ -> mkInd (kn,0)
     in


### PR DESCRIPTION
This leads to a slight simplication of the code.

This has to be merged synchrounously with coq/coq#14692.