### PR TITLE
Adapt to the change of type of the exception IllTypedInstance (Coq PR #14797)

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -416,7 +416,7 @@ let interp_constr_in_rhs env ctx evars data ty s lets c =
   try
     let env' = env_of_rhs evars ctx env s lets in
     interp_constr_in_rhs_env env evars data env' 0 c ty
-  with Evarsolve.IllTypedInstance (env, t, u) ->
+  with Evarsolve.IllTypedInstance _ ->
     anomaly (str"Ill-typed instance in interp_constr_in_rhs")
 
 let unify_type env evars before id ty after =


### PR DESCRIPTION
In the patch, we drop the arguments, which were not used, so that this Equations' PR is backwards-compatible.

PS: In coq/coq#14797, a special variant of `IllTypedInstance` named `llTypedInstanceFun` is introduced. Should it be tested also in `interp_constr_in_rhs`? Alternatively, `IllTypedInstance` is somehow low-level. Can it still arrive these days at the level of abstraction of `Typeclasses.resolve_typeclasse`?