### PR TITLE
Adapt to Coq PR #14711:  universe contexts and universe binders treated together

### DIFF
--- a/src/principles.ml
+++ b/src/principles.ml
@@ -1625,7 +1625,7 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
                                                                   mkSort (Sorts.sort_of_univ sort))) sign) })
         inds
     in
-    let uctx = Evd.univ_entry ~poly sigma in
+    let uctx, ubinders = Evd.univ_entry ~poly sigma in
     let inductive =
       Entries.{ mind_entry_record = None;
                 mind_entry_universes = uctx;
@@ -1638,7 +1638,7 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
               }
     in
     let () = Goptions.set_bool_option_value_gen ~locality:Goptions.OptLocal ["Elimination";"Schemes"] false in
-    let kn = DeclareInd.declare_mutual_inductive_with_eliminations inductive UnivNames.empty_binders [] in
+    let kn = DeclareInd.declare_mutual_inductive_with_eliminations inductive ubinders [] in
     let () = Goptions.set_bool_option_value_gen ~locality:Goptions.OptLocal ["Elimination";"Schemes"] true in
     let sort = Inductiveops.top_allowed_sort (Global.env()) (kn,0) in
     let sort_suff = Indrec.elimination_suffix sort in

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -148,7 +148,7 @@ let derive_subterm ~pm env sigma ~poly (ind, u as indu) =
         mind_entry_consnames = consnames;
         mind_entry_lc = constructors }
   in
-  let uctx = Evd.univ_entry ~poly sigma in
+  let uctx, ubinders = Evd.univ_entry ~poly sigma in
   let declare_ind ~pm =
     let inds = [declare_one_ind 0 indu branches] in
     let inductive =
@@ -162,7 +162,7 @@ let derive_subterm ~pm env sigma ~poly (ind, u as indu) =
         mind_entry_variance = None;
       }
     in
-    let k = DeclareInd.declare_mutual_inductive_with_eliminations inductive UnivNames.empty_binders [] in
+    let k = DeclareInd.declare_mutual_inductive_with_eliminations inductive ubinders [] in
     let () =
       let env = Global.env () in
       let sigma = Evd.from_env env in


### PR DESCRIPTION
`Evd.univ_entry` now returns also the universe binders by default. We seize the opportunity to propagate them when there are some.

To be merged synchronously with coq/coq#14711. Thanks in advance.