### PR TITLE
Adapting to Coq #14718: an ambiguous "Require Wf" was actually useless

### DIFF
--- a/theories/Prop/Classes.v
+++ b/theories/Prop/Classes.v
@@ -7,7 +7,7 @@
 (**********************************************************************)
 
 Require Import Equations.Init Equations.CoreTactics.
-From Coq Require Import Extraction Relation_Definitions Wf.
+From Coq Require Import Extraction Relation_Definitions.
 Require Import Equations.Prop.Logic.
 
 (** A class for well foundedness proofs.


### PR DESCRIPTION
Coq PR coq/coq#14718 is experimenting failing in case of ambiguous `Require`. An ambiguous `From Coq Require Wf` has been detected in ` theories/Prop/Classes.v` but it happens to be useless. We remove it. (As far as I can infer, it had to be useless since, depending on file systems, either `Init.Wf` was reloaded or `Program.Wf` was loaded.)