### PR TITLE
Another useless ambiguous "Require Wf"

### DIFF
--- a/examples/string_matching.v
+++ b/examples/string_matching.v
@@ -6,7 +6,6 @@ Require Import Coq.Program.Wf.
 Require Import List Lia.
 Require Import PeanoNat.
 Require Import Program.
-Require Import Wf.
 From Equations Require Import Equations.
 
 Import ListNotations.


### PR DESCRIPTION
This is a following to #435. There was another `Require Wf` in the `examples` directory which I failed to see, I'm sorry.

It can also be merged as soon as now.

Cc @ppedrot.