### PR TITLE
Addressing a few warnings regarding renamings in context.ml, univ.ml, and deprecated flags

### DIFF
--- a/examples/STLC.v
+++ b/examples/STLC.v
@@ -689,8 +689,6 @@ Ltac invert_term :=
       end
   end.
 
-Set Regular Subst Tactic.
-
 Lemma hereditary_subst_type Γ Γ' t T u U : Γ |-- u : U -> Γ' @ (U :: Γ) |-- t : T ->
   let (t', o) := hereditary_subst (U, u, t) (length Γ') in
     (Γ' @ Γ |-- t' : T /\ (forall ty prf, o = Some (exist ty prf) -> ty = T)).

--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -142,7 +142,7 @@ let depcase ~poly ((mind, i as ind), u) =
   in
   let nconstrs = Array.length oneind.mind_nf_lc in
   let mkbody i (ctx, ty) =
-    let args = Context.Rel.to_extended_vect mkRel 0 ctx in
+    let args = Context.Rel.instance mkRel 0 ctx in
     annot_of_context ctx, mkApp (mkRel (1 + nconstrs + List.length ctx - i), args)
   in
   let bodies = Array.mapi mkbody oneind.mind_nf_lc in
@@ -459,7 +459,7 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
 
     (* Initial problem. *)
     let prob = Context_map.id_subst ctx in
-    let args = Context.Rel.to_extended_list mkRel 0 ctx in
+    let args = Context.Rel.instance_list mkRel 0 ctx in
 
     Refine.refine ~typecheck:true begin fun evars ->
       let evd = ref evars in

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -895,9 +895,9 @@ type named_declaration = EConstr.named_declaration
 type named_context = EConstr.named_context
 
 let extended_rel_vect n ctx =
-  Context.Rel.to_extended_vect mkRel n ctx
+  Context.Rel.instance mkRel n ctx
 let extended_rel_list n ctx =
-  Context.Rel.to_extended_list mkRel n ctx
+  Context.Rel.instance_list mkRel n ctx
 let to_tuple = Context.Rel.Declaration.to_tuple
 let to_named_tuple = Context.Named.Declaration.to_tuple
 let of_named_tuple = Context.Named.Declaration.of_tuple

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -225,8 +225,8 @@ let make_definition ?opaque ?(poly=false) evm ?types b =
   let evm0 = evm in
   let body = EConstr.to_constr evm b and typ = Option.map (EConstr.to_constr evm) types in
   let used = Vars.universes_of_constr body in
-  let used' = Option.cata Vars.universes_of_constr Univ.LSet.empty typ in
-  let used = Univ.LSet.union used used' in
+  let used' = Option.cata Vars.universes_of_constr Univ.Level.Set.empty typ in
+  let used = Univ.Level.Set.union used used' in
   let evm = Evd.restrict_universe_context evm used in
   let univs = Evd.univ_entry ~poly evm in
   evm0, evm, Declare.definition_entry ~univs ?types:typ body

--- a/src/noconf.ml
+++ b/src/noconf.ml
@@ -103,7 +103,7 @@ let derive_no_confusion ~pm env sigma0 ~poly (ind,u as indu) =
   in
   let arity = it_mkProd_or_LetIn s fullbinders in
   let env = push_rel_context binders env in
-  let paramsvect = Context.Rel.to_extended_vect mkRel 0 ctx in
+  let paramsvect = Context.Rel.instance mkRel 0 ctx in
   let pack_ind_with_parlift n = lift n argty in
   let ind_with_parlift n = 
     mkApp (mkIndU indu, Array.append (Array.map (lift n) paramsvect) rest) 

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -145,7 +145,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
   in
   let _arity = it_mkProd_or_LetIn s fullbinders in
   (* let env = push_rel_context binders env in *)
-  let paramsvect = Context.Rel.to_extended_vect mkRel 0 ctx in
+  let paramsvect = Context.Rel.instance mkRel 0 ctx in
   let _pack_ind_with_parlift n = lift n argty in
   let _ind_with_parlift n =
     mkApp (mkIndU indu, Array.append (Array.map (lift n) paramsvect) rest) 

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -214,8 +214,8 @@ let find_rec_call is_rec sigma protos f args =
             let sign = List.map EConstr.Unsafe.to_rel_decl sign in
             let sign = substitute_args indargs sign in
             let signlen = List.length sign in
-            let indargs = List.map (Constr.lift signlen) indargs @ Context.Rel.to_extended_list Constr.mkRel 0 sign in
-            let fargs = List.map (Constr.lift signlen) args @ Context.Rel.to_extended_list Constr.mkRel 0 sign in
+            let indargs = List.map (Constr.lift signlen) indargs @ Context.Rel.instance_list Constr.mkRel 0 sign in
+            let fargs = List.map (Constr.lift signlen) args @ Context.Rel.instance_list Constr.mkRel 0 sign in
             sign, (fargs, indargs, [])
         in
         Some (idx, arity, filter, sign, args)
@@ -294,7 +294,7 @@ let abstract_rec_calls sigma user_obls ?(do_subst=true) is_rec len protos c =
              Term.it_mkProd_or_LetIn
                (Constr.mkApp (mkApp (mkRel (i + 1 + len + n + List.length sign), Array.of_list indargs'),
                               [| Term.applistc (lift (List.length sign) result)
-                                   (Context.Rel.to_extended_list mkRel 0 sign) |]))
+                                   (Context.Rel.instance_list mkRel 0 sign) |]))
                sign
            in
            let hyps = cmap_add hyp !occ hyps in

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -1586,11 +1586,11 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
           Nameops.add_suffix indid suff) n) stmts
     in
     let merge_universes_of_constr c =
-      Univ.LSet.union (EConstr.universes_of_constr !evd c) in
-    let univs = Univ.LSet.union (universes_of_constr !evd arity) univs in
+      Univ.Level.Set.union (EConstr.universes_of_constr !evd c) in
+    let univs = Univ.Level.Set.union (universes_of_constr !evd arity) univs in
     let univs = Context.Rel.(fold_outside (Declaration.fold_constr merge_universes_of_constr) sign ~init:univs) in
     let univs =
-      List.fold_left (fun univs c -> Univ.LSet.union (universes_of_constr !evd (EConstr.of_constr c)) univs)
+      List.fold_left (fun univs c -> Univ.Level.Set.union (universes_of_constr !evd (EConstr.of_constr c)) univs)
         univs constructors in
     let ind_sort =
       match Retyping.get_sort_family_of env !evd (it_mkProd_or_LetIn arity sign) with
@@ -1613,7 +1613,7 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
     in ((entry, sign, arity) :: inds, univs, Univ.sup ind_sort sorts)
   in
   let declare_ind () =
-    let inds, univs, sort = List.fold_left declare_one_ind ([], Univ.LSet.empty, Univ.type0m_univ) ind_stmts in
+    let inds, univs, sort = List.fold_left declare_one_ind ([], Univ.Level.Set.empty, Univ.type0m_univ) ind_stmts in
     let sigma = Evd.restrict_universe_context !evd univs in
     let sigma = Evd.minimize_universes sigma in
     let inds =

--- a/src/sigma_types.ml
+++ b/src/sigma_types.ml
@@ -141,7 +141,7 @@ let telescope env evd = function
               let su = Sorts.univ_of_sort ts in
               Univ.enforce_leq su l cstr
             in
-            let cstrs = enforce_leq env !evd t (Univ.enforce_leq tyuniv l Univ.Constraint.empty) in
+            let cstrs = enforce_leq env !evd t (Univ.enforce_leq tyuniv l Univ.Constraints.empty) in
             let () = evd := Evd.add_constraints !evd cstrs in
             aux (sigty, l, (u, pred) :: tys) ds
         in aux (t, tuniv, []) tl

--- a/src/sigma_types.ml
+++ b/src/sigma_types.ml
@@ -757,7 +757,7 @@ let smart_case (env : Environ.env) (evd : Evd.evar_map ref)
     let term = EConstr.mkConstructU (to_peuniverses summary.Inductiveops.cs_cstr) in
     let term = EConstr.mkApp (term, params) in
     let term = Vars.lift (summary.Inductiveops.cs_nargs) term in
-    let term = EConstr.mkApp (term, Context.Rel.to_extended_vect EConstr.mkRel 0 summary.Inductiveops.cs_args) in
+    let term = EConstr.mkApp (term, Context.Rel.instance EConstr.mkRel 0 summary.Inductiveops.cs_args) in
     (* Indices are typed under [args @ ctx'] *)
     let indices = (Array.to_list indices) @ [term] in
     let args = summary.Inductiveops.cs_args in

--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -257,7 +257,7 @@ let build_app_infer_concl (env : Environ.env) (evd : Evd.evar_map ref) ((ctx, ty
     | Some u ->
       let tf = EConstr.mkRef (f, u) in
       let auctx = Environ.universes_of_global env f in
-      let univs = Univ.AUContext.instantiate (EConstr.EInstance.kind !evd u) auctx in
+      let univs = Univ.AbstractContext.instantiate (EConstr.EInstance.kind !evd u) auctx in
       let sigma = Evd.add_constraints !evd univs in
       let ty = Retyping.get_type_of env sigma tf in
       evd := sigma; tf, ty

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -1060,7 +1060,7 @@ let solve_equations_obligations ~pm flags recids loc i sigma hook =
         Proofview.TCons (evar_env, evm, nf_evar !isevar0 type_,
            (fun evm' wit ->
              isevar0 :=
-               Evd.define ev (applist (wit, List.rev (Context.Named.to_instance mkVar local_context)))
+               Evd.define ev (mkApp (wit, Context.Named.instance mkVar local_context))
                  !isevar0;
              wits := wit :: !wits;
              aux tys evm'))

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -1102,12 +1102,12 @@ let gather_fresh_context sigma u octx =
   let arr = Univ.Instance.to_array u in
   let levels =
     Array.fold_left (fun ctx' l ->
-        if not (Univ.LSet.mem l univs) then Univ.LSet.add l ctx'
+        if not (Univ.Level.Set.mem l univs) then Univ.Level.Set.add l ctx'
         else ctx')
-      Univ.LSet.empty arr
+      Univ.Level.Set.empty arr
   in
   let ctx = Univ.ContextSet.of_set levels in
-  Univ.ContextSet.add_constraints (Univ.AUContext.instantiate u octx) ctx
+  Univ.ContextSet.add_constraints (Univ.AbstractContext.instantiate u octx) ctx
 
 let swap (x, y) = (y, x)
 


### PR DESCRIPTION
Not strictly needed for compiling, but in passing, if ever you are interested in.