### PR TITLE
Remove most V82 compatibility layers

### DIFF
--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -280,11 +280,11 @@ let whd_head env sigma t =
   | _ -> t
 
 let specialize_eqs ~with_block id =
-  Proofview.V82.tactic begin fun gl ->
-  let open Tacticals.Old in
-  let open Tacmach.Old in
+  Proofview.Goal.enter begin fun gl ->
+  let open Tacticals in
+  let open Tacmach in
   let env = pf_env gl in
-  let ty = pf_get_hyp_typ gl id in
+  let ty = pf_get_hyp_typ id gl in
   let evars = ref (project gl) in
   let unif env ctx evars c1 c2 =
     match Evarconv.unify env !evars Reduction.CONV (it_mkLambda_or_subst env c1 ctx) (it_mkLambda_or_subst env c2 ctx) with
@@ -351,26 +351,28 @@ let specialize_eqs ~with_block id =
   let ty = Evarutil.nf_evar !evars ty in
   let acc = Evarutil.nf_evar !evars acc in
     if worked then
-      tclTHENFIRST (to82 (Tactics.assert_before_replacing id ty))
-        (to82 (exact_no_check acc)) gl
+      tclTHENFIRST (Tactics.assert_before_replacing id ty)
+        (exact_no_check acc)
     else tclFAIL 0 (str "Nothing to do in hypothesis " ++ Id.print id ++
                     Printer.pr_econstr_env env !evars ty
-                   ) gl
+                   )
   end
 
+exception Specialize
+
+open Proofview.Notations
+
 let specialize_eqs ~with_block id =
-  Proofview.V82.tactic begin fun gl ->
-  if
-    (try ignore(to82 (clear [id]) gl); false
-     with e when CErrors.noncritical e -> true)
-  then
-    Tacticals.Old.tclFAIL 0 (str "Specialization not allowed on dependent hypotheses") gl
-  else Proofview.V82.of_tactic (specialize_eqs ~with_block id) gl
+  let open Tacticals in
+  Proofview.Goal.enter begin fun gl ->
+  Proofview.tclORELSE (clear [id] <*> Proofview.tclZERO Specialize) begin function
+  | (Specialize, _) -> specialize_eqs ~with_block id
+  | e -> tclFAIL 0 (str "Specialization not allowed on dependent hypotheses")
+  end
   end
 
 (* Dependent elimination using Equations. *)
 let dependent_elim_tac ?patterns id : unit Proofview.tactic =
-  let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in

--- a/src/depelim.mli
+++ b/src/depelim.mli
@@ -41,7 +41,7 @@ val derive_dep_elimination
 val pattern_call :
   ?pattern_term:bool -> constr -> unit Proofview.tactic
 
-val specialize_eqs : with_block:bool -> Names.Id.t -> Proofview.V82.tac
+val specialize_eqs : with_block:bool -> Names.Id.t -> unit Proofview.tactic
 
 val compare_upto_variables : Evd.evar_map -> constr -> constr -> bool
 

--- a/src/equations.mli
+++ b/src/equations.mli
@@ -46,9 +46,9 @@ val equations_interactive :
   Declare.OblState.t * Declare.Proof.t
 
 val solve_equations_goal :
-  Proofview.V82.tac ->
-  Proofview.V82.tac ->
-  Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
+  unit Proofview.tactic ->
+  unit Proofview.tactic ->
+  unit Proofview.tactic
 
 val dependencies :
   env -> Evd.evar_map ->

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -32,11 +32,7 @@ type flags = {
   with_eqns : bool;
   with_ind : bool;
   allow_aliases : bool;
-  tactic : unit Proofview.tactic }  
-  
-(* Tactics *)
-val to82 : 'a Proofview.tactic -> Proofview.V82.tac
-val of82 : Proofview.V82.tac -> unit Proofview.tactic
+  tactic : unit Proofview.tactic }
 
 (* Point-free composition *)
 val ( $ ) : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -65,9 +65,6 @@ type 'a located = 'a Loc.located
 (** Fresh names *)
 val fresh_id_in_env :
   Names.Id.Set.t -> Names.Id.t -> Environ.env -> Names.Id.t
-val fresh_id :
-  Names.Id.Set.t ->
-  Names.Id.t -> Goal.goal Evd.sigma -> Names.Id.t
 
 (** Refer to a tactic *)
 val tac_of_string :
@@ -294,8 +291,7 @@ val coq_end_of_section : Names.GlobRef.t Lazy.t
 val coq_ImpossibleCall : esigma -> constr
 val unfold_add_pattern : unit Proofview.tactic lazy_t
 
-val observe : string -> Proofview.V82.tac -> Proofview.V82.tac
-val observe_new : string -> unit Proofview.tactic -> unit Proofview.tactic
+val observe : string -> unit Proofview.tactic -> unit Proofview.tactic
   
 val below_tactics_path : Names.DirPath.t
 val below_tac : string -> Names.KerName.t
@@ -334,7 +330,7 @@ val autounfold_heads :
   Hints.hint_db_name list ->
   Hints.hint_db_name list ->
   Locus.hyp_location option ->
-  Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
+  unit Proofview.tactic
 val specialize_mutfix_tac : unit -> unit Proofview.tactic
 
 type hintdb_name = string

--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -23,8 +23,6 @@ open Equations_common
 open EConstr
 open Ltac_plugin
 
-let of82 = Proofview.V82.tactic
-
 }
 
 TACTIC EXTEND decompose_app
@@ -98,8 +96,8 @@ open Tacarg
 
 TACTIC EXTEND solve_equations
 | [ "solve_equations" tactic(destruct) tactic(tac) ] -> 
-     { of82 (Equations.solve_equations_goal (to82 (Tacinterp.tactic_of_value ist destruct))
-                                            (to82 (Tacinterp.tactic_of_value ist tac))) }
+     { Equations.solve_equations_goal (Tacinterp.tactic_of_value ist destruct)
+                                            (Tacinterp.tactic_of_value ist tac) }
 END
 
 TACTIC EXTEND simp
@@ -520,10 +518,10 @@ END
 
 TACTIC EXTEND eqns_specialize_eqs
 | [ "eqns_specialize_eqs" ident(i) ] -> {
-    Proofview.V82.tactic (Depelim.specialize_eqs ~with_block:false i)
+    Depelim.specialize_eqs ~with_block:false i
   }
 | [ "eqns_specialize_eqs_block" ident(i) ] -> {
-    Proofview.V82.tactic (Depelim.specialize_eqs ~with_block:true i)
+    Depelim.specialize_eqs ~with_block:true i
   }
 END
 

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -596,7 +596,7 @@ let where_instance w =
 let arguments sigma c = snd (Termops.decompose_app_vect sigma c)
 
 let unfold_constr sigma c =
-  to82 (Tactics.unfold_in_concl [(Locus.OnlyOccurrences [1], Tacred.EvalConstRef (fst (destConst sigma c)))])
+  Tactics.unfold_in_concl [(Locus.OnlyOccurrences [1], Tacred.EvalConstRef (fst (destConst sigma c)))]
 
 let extend_prob_ctx delta (ctx, pats, ctx') =
   (delta @ ctx, Context_map.lift_pats (List.length delta) pats, ctx')
@@ -1517,7 +1517,7 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
       | None -> fl,
         if eq_constr !evd fl f then
           Tacticals.tclORELSE Tactics.reflexivity
-            (Tacticals.tclTHEN (of82 (unfold_constr !evd f)) unfold_fix)
+            (Tacticals.tclTHEN (unfold_constr !evd f) unfold_fix)
         else Tacticals.tclIDTAC
     in
     let comp = applistc hd pats in

--- a/src/principles.mli
+++ b/src/principles.mli
@@ -79,7 +79,7 @@ val pr_where :
   Environ.env -> Evd.evar_map -> Constr.rel_context -> Splitting.where_clause -> Pp.t
 val where_instance : Splitting.where_clause list -> constr list
 val arguments : Evd.evar_map -> constr -> constr array
-val unfold_constr : Evd.evar_map -> constr -> Proofview.V82.tac
+val unfold_constr : Evd.evar_map -> constr -> unit Proofview.tactic
 
 (** Unfolding lemma tactic *)
 

--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -23,6 +23,9 @@ open Vars
 
 open Cc_plugin.Cctac
 
+let to82 t = Proofview.V82.of_tactic t
+let of82 t = Proofview.V82.tactic t
+
 type where_map = (constr * Names.Id.t * splitting) PathMap.t
 
 type equations_info = {

--- a/src/principles_proofs.mli
+++ b/src/principles_proofs.mli
@@ -18,7 +18,7 @@ val find_helper_info : Environ.env -> Evd.evar_map ->
   Splitting.term_info ->
   EConstr.t -> Names.Constant.t * (int * int)
 val below_transparent_state : unit -> TransparentState.t
-val simpl_star : Proofview.V82.tac
+val simpl_star : unit Proofview.tactic
 val eauto_with_below :
   ?depth:Int.t -> ?strategy:Class_tactics.search_strategy -> Hints.hint_db_name list -> unit Proofview.tactic
 val wf_obligations_base : Splitting.term_info -> string
@@ -69,8 +69,7 @@ val prove_unfolding_lemma :
   Names.Constant.t ->
   Names.Constant.t ->
   Splitting.program -> Splitting.program ->
-  Goal.goal Evd.sigma ->
-  Goal.goal list Evd.sigma
+  unit Proofview.tactic
   
 val ind_elim_tac :
   constr ->


### PR DESCRIPTION
All the remaining uses are concentrated in src/principles_proofs.ml. There are weird things going on there so I have to sort it out a bit but it doesn't hurt to remove the rest.