### PR TITLE
Support deriving noconfusion for constructors with sprop arguments

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -416,16 +416,19 @@ let unfold_add_pattern =
 
 let subterm_relation_base = "subterm_relation"
 
-let coq_sigma = (find_global "sigma.type")
-let coq_sigmaI = (find_global "sigma.intro")
-
 let init_projection gr =
   let cst = Globnames.destConstRef gr in
   let p = Option.get @@ Recordops.find_primitive_projection cst in
   Projection.make p false
 			
+let coq_sigma = (find_global "sigma.type")
+let coq_sigmaI = (find_global "sigma.intro")
 let coq_pr1 = lazy (init_projection (Lazy.force (find_global "sigma.pr1")))
 let coq_pr2 = lazy (init_projection (Lazy.force (find_global "sigma.pr2")))
+let coq_sigmaTS = (find_global "sigmaTS.type")
+let coq_sigmaTSI = (find_global "sigmaTS.intro")
+let coq_pr1TS = lazy (init_projection (Lazy.force (find_global "sigmaTS.pr1")))
+let coq_pr2TS = lazy (init_projection (Lazy.force (find_global "sigmaTS.pr2")))
 			    
 (* Misc tactics *)
 

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -234,6 +234,11 @@ val coq_sigmaI : lazy_ref
 val coq_pr1 : Names.Projection.t lazy_t
 val coq_pr2 : Names.Projection.t lazy_t
 
+val coq_sigmaTS : lazy_ref
+val coq_sigmaTSI : lazy_ref
+val coq_pr1TS : Names.Projection.t lazy_t
+val coq_pr2TS : Names.Projection.t lazy_t
+
 val logic_tele_type : lazy_ref
 val logic_tele_tip : lazy_ref
 val logic_tele_ext : lazy_ref

--- a/src/noconf.ml
+++ b/src/noconf.ml
@@ -132,7 +132,7 @@ let derive_no_confusion ~pm env sigma0 ~poly (ind,u as indu) =
 	        (fun _ i' id' nparams args' arity' ->
 	          if i = i' then
 	            if List.length args = 0 then tru
-                    else mk_eq env env' evd args args'
+              else mk_eq env env' evd args args'
 	          else fls)))
   in
   let app = it_mkLambda_or_LetIn pred binders in

--- a/src/sigma_types.ml
+++ b/src/sigma_types.ml
@@ -47,13 +47,23 @@ let constrs_of_coq_sigma env evd t alias =
     | App (f, args) when is_global !evd (Lazy.force coq_sigmaI) f && 
 	                   Array.length args = 4 ->
        let ty = Retyping.get_type_of env !evd args.(1) in
-	(match kind !evd ty with
-	| Prod (n, b, t) ->
-	    let p1 = mkProj (Lazy.force coq_pr1, proj) in
-	    let p2 = mkProj (Lazy.force coq_pr2, proj) in
-	    (n, args.(2), p1, args.(0)) ::
-              aux (push_rel (of_tuple (n, None, b)) env) p2 args.(3) t
-	| _ -> raise (Invalid_argument "constrs_of_coq_sigma"))
+      (match kind !evd ty with
+      | Prod (n, b, t) ->
+          let p1 = mkProj (Lazy.force coq_pr1, proj) in
+          let p2 = mkProj (Lazy.force coq_pr2, proj) in
+          (n, args.(2), p1, args.(0)) ::
+                  aux (push_rel (of_tuple (n, None, b)) env) p2 args.(3) t
+      | _ -> raise (Invalid_argument "constrs_of_coq_sigma"))
+    | App (f, args) when is_global !evd (Lazy.force coq_sigmaTSI) f && 
+	                   Array.length args = 4 ->
+       let ty = Retyping.get_type_of env !evd args.(1) in
+      (match kind !evd ty with
+      | Prod (n, b, t) ->
+          let p1 = mkProj (Lazy.force coq_pr1TS, proj) in
+          let p2 = mkProj (Lazy.force coq_pr2TS, proj) in
+          (n, args.(2), p1, args.(0)) ::
+                  aux (push_rel (of_tuple (n, None, b)) env) p2 args.(3) t
+      | _ -> raise (Invalid_argument "constrs_of_coq_sigma"))
     | _ -> [(Context.anonR, c, proj, ty)]
   in aux env alias t (Retyping.get_type_of env !evd t)
 
@@ -97,6 +107,13 @@ let telescope_intro env sigma len tele =
     | _ -> mkRel n
   in aux len tele
 
+type sigma_info = {
+  sigma_type : GlobRef.t;
+  sigma_intro : GlobRef.t;
+  sigma_pr1 : Names.Projection.t;
+  sigma_pr2 : Names.Projection.t;
+}
+
 let telescope_of_context env sigma ctx =
   let sigma, teleinterp = new_global sigma (Lazy.force logic_tele_interp) in
   let _, u = destConst sigma teleinterp in
@@ -123,18 +140,35 @@ let telescope env evd = function
       let len = succ (List.length tl) in
       let ts = Retyping.get_sort_of (push_rel_context tl env) !evd t in
       let tuniv = Sorts.univ_of_sort ts in
+      let trel = Sorts.relevance_of_sort ts in
       let ty, tys =
-        let rec aux (ty, tyuniv, tys) ds =
+        let rec aux (ty, tyuniv, trel, tys) ds =
           match ds with
           | [] -> (ty, tys)
           | d :: ds ->
             let (n, b, t) = to_tuple d in
             let pred = mkLambda (n, t, ty) in
-            let sigty = mkAppG evd (Lazy.force coq_sigma) [|t; pred|] in
+            let env = push_rel_context ds env in
+            let _relt = 
+              let ts = Retyping.get_sort_of env !evd t in
+              Sorts.relevance_of_sort ts
+            in
+            let sigmainfo =
+              if trel == Sorts.Irrelevant then
+                { sigma_type = Lazy.force coq_sigmaTS;
+                  sigma_intro = Lazy.force coq_sigmaTSI;
+                  sigma_pr1 = Lazy.force coq_pr1TS;
+                  sigma_pr2 = Lazy.force coq_pr2TS }
+              else
+                { sigma_type = Lazy.force coq_sigma;
+                  sigma_intro = Lazy.force coq_sigmaI;
+                  sigma_pr1 = Lazy.force coq_pr1;
+                  sigma_pr2 = Lazy.force coq_pr2 }
+            in
+            let sigty = mkAppG evd sigmainfo.sigma_type [|t; pred|] in
             let _, u = destInd !evd (fst (destApp !evd sigty)) in
             let ua = Univ.Instance.to_array (EInstance.kind !evd u) in
             let l = Univ.Universe.make ua.(0) in
-            let env = push_rel_context ds env in
             (* Ensure that the universe of the sigma is only >= those of t and pred *)
             let enforce_leq env sigma t cstr =
               let ts = Retyping.get_sort_of env sigma t in
@@ -143,26 +177,26 @@ let telescope env evd = function
             in
             let cstrs = enforce_leq env !evd t (Univ.enforce_leq tyuniv l Univ.Constraint.empty) in
             let () = evd := Evd.add_constraints !evd cstrs in
-            aux (sigty, l, (u, pred) :: tys) ds
-        in aux (t, tuniv, []) tl
+            aux (sigty, l, Sorts.Relevant, (u, pred, sigmainfo) :: tys) ds
+        in aux (t, tuniv, trel, []) tl
       in
       let constr, _ = 
-	List.fold_right (fun (u, pred) (intro, k) ->
-	  let pred = Vars.lift k pred in
-	  let (n, dom, codom) = destLambda !evd pred in
-	  let intro =
-            mkApp (constr_of_global_univ !evd (Lazy.force coq_sigmaI, u),
-                   [| dom; pred; mkRel k; intro|]) in
-	    (intro, succ k))
-	  tys (mkRel 1, 2)
+        List.fold_right (fun (u, pred, sigmainfo) (intro, k) ->
+          let pred = Vars.lift k pred in
+          let (n, dom, codom) = destLambda !evd pred in
+          let intro =
+                  mkApp (constr_of_global_univ !evd (sigmainfo.sigma_intro, u),
+                        [| dom; pred; mkRel k; intro|]) in
+            (intro, succ k))
+          tys (mkRel 1, 2)
       in
       let (last, _, subst) = List.fold_right2
-	(fun pred d (prev, k, subst) ->
+        (fun (_, _, sigmainfo) d (prev, k, subst) ->
           let (n, b, t) = to_tuple d in
-	  let proj1 = mkProj (Lazy.force coq_pr1, prev) in
-	  let proj2 = mkProj (Lazy.force coq_pr2, prev) in
-	    (Vars.lift 1 proj2, succ k, of_tuple (n, Some proj1, Vars.liftn 1 k t) :: subst))
-	(List.rev tys) tl (mkRel 1, 1, [])
+          let proj1 = mkProj (sigmainfo.sigma_pr1, prev) in
+          let proj2 = mkProj (sigmainfo.sigma_pr2, prev) in
+            (Vars.lift 1 proj2, succ k, of_tuple (n, Some proj1, Vars.liftn 1 k t) :: subst))
+        (List.rev tys) tl (mkRel 1, 1, [])
       in ty, (of_tuple (n, Some last, Vars.liftn 1 len t) :: subst), constr
 
 let sigmaize ?(liftty=0) env0 evd pars f =
@@ -338,9 +372,9 @@ let pattern_sigma ~assoc_right c hyp env sigma =
   let terms =
     if assoc_right then terms
     else match terms with
-         | (x, t, p, rest) :: term :: _ -> 
-	    constrs_of_coq_sigma env evd t p @ terms
-         | _ -> terms
+      | (x, t, p, rest) :: term :: _ -> 
+	      constrs_of_coq_sigma env evd t p @ terms
+      | _ -> terms
   in
   let pat x = Patternops.pattern_of_constr env !evd (to_constr !evd x) in
   let terms = 

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -65,6 +65,7 @@ issues/issue258.v
 issues/issue286.v
 issues/issue297.v
 issues/issue306.v
+issues/issue321.v
 issues/issue328.v
 issues/issue329.v
 issues/issue338.v
@@ -72,8 +73,8 @@ issues/issue346.v
 issues/issue349.v
 issues/issue353.v
 issues/issue354.v
+issues/issue365.v
 issues/issue372.v
-issues/issue321.v
 issues/issue399.v
 issues/issue449.v
 eqdec_error.v

--- a/test-suite/issues/issue365.v
+++ b/test-suite/issues/issue365.v
@@ -1,0 +1,15 @@
+From Equations Require Import CoreTactics.
+From Equations Require Import Equations.
+
+Inductive Squash (A : Type) : SProp :=
+  | sq : A -> Squash A.
+
+Class Positive (n : nat) : SProp :=
+  is_positive : Squash (0 < n).
+
+Record positive := mkpos {
+  pos : nat ;
+  cond_pos : Positive pos
+}.
+
+Derive NoConfusion NoConfusionHom for positive.

--- a/theories/HoTT/Constants.v
+++ b/theories/HoTT/Constants.v
@@ -11,10 +11,16 @@ Register Basics.Datatypes.S as equations.nat.succ.
 Register Basics.Datatypes.nat as equations.nat.type.
 
 (* Sigma Types *)
+
 Register Equations.Init.sigma as equations.sigma.type.
 Register Equations.Init.sigmaI as equations.sigma.intro.
 Register Equations.Init.pr1 as equations.sigma.pr1.
 Register Equations.Init.pr2 as equations.sigma.pr2.
+
+Register Equations.Init.sigmaS as equations.sigmaTS.type.
+Register Equations.Init.sigmaSI as equations.sigmaTS.intro.
+Register Equations.Init.pr1S as equations.sigmaTS.pr1.
+Register Equations.Init.pr2S as equations.sigmaTS.pr2.
 
 (** Classes *)
 
@@ -83,6 +89,11 @@ Register DepElim.simplification_sigma1 as equations.depelim.simpl_sigma.
 Register DepElim.simplification_sigma1_dep as equations.depelim.simpl_sigma_dep.
 Register DepElim.simplification_sigma1_nondep_dep as equations.depelim.simpl_sigma_nondep_dep.
 Register DepElim.simplification_sigma1_dep_dep as equations.depelim.simpl_sigma_dep_dep.
+
+Register DepElim.simplification_sigma1S as equations.depelim.simpl_sigmaS.
+Register DepElim.simplification_sigma1S_dep as equations.depelim.simpl_sigmaS_dep.
+Register DepElim.simplification_sigma1S_nondep_dep as equations.depelim.simpl_sigmaS_nondep_dep.
+Register DepElim.simplification_sigma1S_dep_dep as equations.depelim.simpl_sigmaS_dep_dep.
 
 Register DepElim.simplify_ind_pack as equations.depelim.simplify_ind_pack.
 Register DepElim.simplify_ind_pack_inv as equations.depelim.simplify_ind_pack_inv.

--- a/theories/HoTT/DepElim.v
+++ b/theories/HoTT/DepElim.v
@@ -111,6 +111,30 @@ Proof.
   exact (eq 1 1).
 Defined.
 
+Lemma simplification_sigma1S@{i j |} {A : Type@{i}} {P : SProp} {B : Type@{j}}
+  (p q : A) (x : P) (y : P) :
+  (p = q -> B) -> ((sigmaSI _ p x) = (sigmaSI _ q y) -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct X0.
+  intros X. exact (X idpath).
+Defined.
+
+Lemma simplification_sigma1S_dep@{i j|} {A : Type@{i}}
+  {P : A -> SProp} {B : Type@{j}}
+  (p q : A) (x : P p) (y : P q) :
+  (p = q -> B) ->
+  ((sigmaSI _ p x) = (sigmaSI _ q y) -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct X0. cbn.
+  intros X. eapply (X idpath).
+Defined.
+
 Lemma simplification_sigma1_dep@{i j |} {A : Type@{i}} {P : A -> Type@{i}} {B : Type@{j}}
   (p q : A) (x : P p) (y : P q) :
   (forall e : paths@{i} p q, paths (transport@{i i} P e x) y -> B) ->
@@ -144,6 +168,27 @@ Proof.
   apply (X 1 1).
 Defined.
 
+Polymorphic Definition pack_sigmaS_eq_nondep@{i|} {A : Type@{i}} {P : SProp} 
+  {p q : A} {x : P} {y : P}
+  (e' : p = q) : sigmaSI _ p x = sigmaSI _ q y.
+Proof. destruct e'. apply idpath. Defined.
+
+Polymorphic Lemma simplification_sigma1S_nondep_dep@{i j|} {A : Type@{i}} 
+  {P : SProp}
+  (p q : A) (x : P) (y : P) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : p = q, B (pack_sigmaS_eq_nondep e')) ->
+  (forall e : sigmaSI (fun _ => P) p x = sigmaSI (fun _ => P) q y, B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  change x with (pr2S (sigmaSI _ p x)) at 2.
+  change y with (pr2S (sigmaSI _ q y)) at 3.
+  destruct e.
+  intros X. simpl in *.
+  apply (X idpath).
+Defined.
+
 Definition pack_sigma@{i|} {A : Type@{i}} {P : A -> Type@{i}} {p q : A} {x : P p} {y : P q}
   (e' : p = q) (e : e' # x = y) : (p, x) = (q, y).
 Proof. destruct e'. simpl in e. destruct e. apply 1. Defined.
@@ -163,18 +208,26 @@ Proof.
   apply (X 1 1).
 Defined.
 
-(*  Lemma simplification_sigma1'@{i j} {A : Type@{i}} {P : A -> Type@{i}} {B : Type@{j}} (p q : A) (x : P p) (y : P q) : *)
-(*   (forall e : paths p q, paths (paths_rew A p P x q e) y -> B) -> *)
-(*   (paths ((p, x)) ((q, y)) -> B). *)
-(* Proof. *)
-(*   intros. revert X. *)
-(*   change p with (pr1 (p, x)). *)
-(*   change q with (pr1 (q, y)). *)
-(*   change x with (pr2 (p, x)) at 3. *)
-(*   change y with (pr2 (q, y)) at 4. *)
-(*   destruct X0. *)
-(*   intros X. eapply (X id_refl). apply id_refl. *)
-(* Defined. *)
+Polymorphic Definition pack_sigmaS_eq@{i |} {A : Type@{i}} {P : A -> SProp} {p q : A} {x : P p} {y : P q}
+  (e' : p = q) : (sigmaSI _ p x) = (sigmaSI _ q y).
+Proof. destruct e'. apply idpath. Defined.
+
+Polymorphic Lemma simplification_sigma1S_dep_dep@{i j|}
+  {A : Type@{i}} {P : A -> SProp}
+  (p q : A) (x : P p) (y : P q) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : p = q, B (pack_sigmaS_eq e')) ->
+  (forall e : (sigmaSI _ p x) = (sigmaSI _ q y), B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  unfold pack_sigmaS_eq.
+  change x with (pr2S (sigmaSI _ p x)) at 3 5.
+  change y with (pr2S (sigmaSI _ q y)) at 2.
+  destruct e.
+  intros X. simpl in *.
+  apply (X idpath).
+Defined.
 
 Lemma pr2_inv_uip@{i|} {A : Type@{i}}
             {P : A -> Type@{i}} {x : A} {y y' : P x} :

--- a/theories/Init.v
+++ b/theories/Init.v
@@ -100,6 +100,15 @@ End Sigma_Notations.
 
 Import Sigma_Notations.
 
+Set Primitive Projections.
+Global Unset Printing Primitive Projection Parameters.
+Polymorphic Cumulative Record sigmaS@{i} {A : Type@{i}} {B : forall (_ : A), SProp} : Type@{i} :=
+  sigmaSI { pr1S : A; pr2S : B pr1S }.
+Unset Primitive Projections.
+Arguments sigmaS {A} B.
+Arguments sigmaSI {A} B pr1S pr2S.
+
+Extraction Inline pr1S pr2S.
 
 (** Forward reference for the no-confusion tactic. *)
 Ltac noconf H := fail "Equations.Init.noconf has not been bound yet".

--- a/theories/Prop/Constants.v
+++ b/theories/Prop/Constants.v
@@ -14,6 +14,11 @@ Register Equations.Init.sigmaI as equations.sigma.intro.
 Register Equations.Init.pr1 as equations.sigma.pr1.
 Register Equations.Init.pr2 as equations.sigma.pr2.
 
+Register Equations.Init.sigmaS as equations.sigmaTS.type.
+Register Equations.Init.sigmaSI as equations.sigmaTS.intro.
+Register Equations.Init.pr1S as equations.sigmaTS.pr1.
+Register Equations.Init.pr2S as equations.sigmaTS.pr2.
+
 (** Classes *)
 
 Register DepElim.DependentEliminationPackage as equations.depelim.class.
@@ -71,6 +76,11 @@ Register Equations.Prop.DepElim.eq_simplification_sigma1 as equations.depelim.si
 Register Equations.Prop.DepElim.eq_simplification_sigma1_dep as equations.depelim.simpl_sigma_dep.
 Register Equations.Prop.DepElim.eq_simplification_sigma1_nondep_dep as equations.depelim.simpl_sigma_nondep_dep.
 Register Equations.Prop.DepElim.eq_simplification_sigma1_dep_dep as equations.depelim.simpl_sigma_dep_dep.
+
+Register Equations.Prop.DepElim.eq_simplification_sigma1S as equations.depelim.simpl_sigmaS.
+Register Equations.Prop.DepElim.eq_simplification_sigma1S_dep as equations.depelim.simpl_sigmaS_dep.
+Register Equations.Prop.DepElim.eq_simplification_sigma1S_nondep_dep as equations.depelim.simpl_sigmaS_nondep_dep.
+Register Equations.Prop.DepElim.eq_simplification_sigma1S_dep_dep as equations.depelim.simpl_sigmaS_dep_dep.
 
 Register Equations.Prop.DepElim.simplify_ind_pack as equations.depelim.simplify_ind_pack.
 Register Equations.Prop.DepElim.simplify_ind_pack_inv as equations.depelim.simplify_ind_pack_inv.

--- a/theories/Prop/DepElim.v
+++ b/theories/Prop/DepElim.v
@@ -125,6 +125,18 @@ Proof.
   intros X. eapply (X eq_refl). apply eq_refl.
 Defined.
 
+Polymorphic Lemma eq_simplification_sigma1S@{i j | i <= eq.u0} {A : Type@{i}} {P : SProp} {B : Type@{j}}
+  (p q : A) (x : P) (y : P) :
+  (p = q -> B) ->
+  ((sigmaSI _ p x) = (sigmaSI _ q y) -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct H.
+  intros X. exact (X eq_refl).
+Defined.
+
 Polymorphic Lemma eq_simplification_sigma1_dep@{i j | i <= eq.u0 +} {A : Type@{i}} {P : A -> Type@{i}} {B : Type@{j}}
   (p q : A) (x : P p) (y : P q) :
   (forall e : p = q, (@eq_rect A p P x q e) = y -> B) ->
@@ -137,6 +149,19 @@ Proof.
   change y with (pr2 (q, y)) at 4.
   destruct H.
   intros X. eapply (X eq_refl). apply eq_refl.
+Defined.
+
+Polymorphic Lemma eq_simplification_sigma1S_dep@{i j | i <= eq.u0 +} 
+  {A : Type@{i}} {P : A -> SProp} {B : Type@{j}}
+  (p q : A) (x : P p) (y : P q) :
+  (p = q -> B) ->
+  (sigmaSI _ p x = sigmaSI _ q y -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct H. cbn.
+  intros X. eapply (X eq_refl).
 Defined.
 
 Polymorphic Definition pack_sigma_eq_nondep@{i | i <= eq.u0} {A : Type@{i}} {P : Type@{i}} {p q : A} {x : P} {y : P}
@@ -158,6 +183,27 @@ Proof.
   apply (X eq_refl eq_refl).
 Defined.
 
+Polymorphic Definition pack_sigmaS_eq_nondep@{i | i <= eq.u0} {A : Type@{i}} {P : SProp} 
+  {p q : A} {x : P} {y : P}
+  (e' : p = q) : sigmaSI _ p x = sigmaSI _ q y.
+Proof. destruct e'. apply eq_refl. Defined.
+
+Polymorphic Lemma eq_simplification_sigma1S_nondep_dep@{i j | i <= eq.u0} {A : Type@{i}} 
+  {P : SProp}
+  (p q : A) (x : P) (y : P) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : p = q, B (pack_sigmaS_eq_nondep e')) ->
+  (forall e : sigmaSI (fun _ => P) p x = sigmaSI (fun _ => P) q y, B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  change x with (pr2S (sigmaSI _ p x)) at 2.
+  change y with (pr2S (sigmaSI _ q y)) at 3.
+  destruct e.
+  intros X. simpl in *.
+  apply (X eq_refl).
+Defined.
+
 Polymorphic Definition pack_sigma_eq@{i | +} {A : Type@{i}} {P : A -> Type@{i}} {p q : A} {x : P p} {y : P q}
   (e' : p = q) (e : @eq_rect A p P x q e' = y) : (p, x) = (q, y).
 Proof. destruct e'. simpl in e. destruct e. apply eq_refl. Defined.
@@ -176,7 +222,28 @@ Proof.
   intros X. simpl in *.
   apply (X eq_refl eq_refl).
 Defined.
-Set Printing Universes.
+
+Polymorphic Definition pack_sigmaS_eq@{i | +} {A : Type@{i}} {P : A -> SProp} {p q : A} {x : P p} {y : P q}
+  (e' : p = q) : sigmaSI _ p x = sigmaSI _ q y.
+Proof. destruct e'. apply eq_refl. Defined.
+
+Polymorphic Lemma eq_simplification_sigma1S_dep_dep@{i j | i <= eq.u0 +} 
+  {A : Type@{i}} {P : A -> SProp}
+  (p q : A) (x : P p) (y : P q) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : p = q, B (pack_sigmaS_eq e')) ->
+  (forall e : sigmaSI _ p x = sigmaSI _ q y, B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  unfold pack_sigmaS_eq.
+  change x with (pr2S (sigmaSI _ p x)) at 3 5.
+  change y with (pr2S (sigmaSI _ q y)) at 2.
+  destruct e.
+  intros X. simpl in *.
+  apply (X eq_refl).
+Defined.
+
 Polymorphic Lemma pr2_inv_uip@{i| i <= eq.u0 +} {A : Type@{i}}
             {P : A -> Type@{i}} {x : A} {y y' : P x} :
   y = y' -> sigmaI@{i} P x y = sigmaI@{i} P x y'.

--- a/theories/Type/Constants.v
+++ b/theories/Type/Constants.v
@@ -16,6 +16,11 @@ Register Equations.Init.sigmaI as equations.sigma.intro.
 Register Equations.Init.pr1 as equations.sigma.pr1.
 Register Equations.Init.pr2 as equations.sigma.pr2.
 
+Register Equations.Init.sigmaS as equations.sigmaTS.type.
+Register Equations.Init.sigmaSI as equations.sigmaTS.intro.
+Register Equations.Init.pr1S as equations.sigmaTS.pr1.
+Register Equations.Init.pr2S as equations.sigmaTS.pr2.
+
 (** Classes *)
 
 Register DepElim.DependentEliminationPackage as equations.depelim.class.
@@ -74,6 +79,11 @@ Register DepElim.simplification_sigma1 as equations.depelim.simpl_sigma.
 Register DepElim.simplification_sigma1_dep as equations.depelim.simpl_sigma_dep.
 Register DepElim.simplification_sigma1_nondep_dep as equations.depelim.simpl_sigma_nondep_dep.
 Register DepElim.simplification_sigma1_dep_dep as equations.depelim.simpl_sigma_dep_dep.
+
+Register DepElim.simplification_sigma1S as equations.depelim.simpl_sigmaS.
+Register DepElim.simplification_sigma1S_dep as equations.depelim.simpl_sigmaS_dep.
+Register DepElim.simplification_sigma1S_nondep_dep as equations.depelim.simpl_sigmaS_nondep_dep.
+Register DepElim.simplification_sigma1S_dep_dep as equations.depelim.simpl_sigmaS_dep_dep.
 
 Register DepElim.simplify_ind_pack as equations.depelim.simplify_ind_pack.
 Register DepElim.simplify_ind_pack_inv as equations.depelim.simplify_ind_pack_inv.

--- a/theories/Type/DepElim.v
+++ b/theories/Type/DepElim.v
@@ -112,6 +112,18 @@ Proof.
   exact (eq 1 1).
 Defined.
 
+Polymorphic Lemma simplification_sigma1S@{i j | i <= eq.u0} {A : Type@{i}} {P : SProp} {B : Type@{j}}
+  (p q : A) (x : P) (y : P) :
+  (p = q -> B) ->
+  ((sigmaSI _ p x) = (sigmaSI _ q y) -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct X0.
+  intros X. exact (X id_refl).
+Defined.
+
 Lemma simplification_sigma1_dep@{i j|} {A : Type@{i}} {P : A -> Type@{i}} {B : Type@{j}}
   (p q : A) (x : P p) (y : P q) :
   (forall e : Id@{i} p q, Id (@Id_rew@{i i} A p P x q e) y -> B) ->
@@ -124,6 +136,19 @@ Proof.
   change y with (pr2 (q, y)) at 4.
   destruct X0.
   intros X. eapply (X id_refl). apply id_refl.
+Defined.
+
+Polymorphic Lemma simplification_sigma1S_dep@{i j|} {A : Type@{i}}
+  {P : A -> SProp} {B : Type@{j}}
+  (p q : A) (x : P p) (y : P q) :
+  (Id@{i} p q -> B) ->
+  (Id (sigmaSI _ p x) (sigmaSI _ q y) -> B).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  destruct X0. cbn.
+  intros X. eapply (X id_refl).
 Defined.
 
 Definition pack_sigma_nondep@{i} {A : Type@{i}} {P : Type@{i}} {p q : A} {x : P} {y : P}
@@ -145,6 +170,27 @@ Proof.
   apply (X id_refl id_refl).
 Defined.
 
+Polymorphic Definition pack_sigmaS_eq_nondep@{i | i <= eq.u0} {A : Type@{i}} {P : SProp} 
+  {p q : A} {x : P} {y : P}
+  (e' : p = q) : sigmaSI _ p x = sigmaSI _ q y.
+Proof. destruct e'. apply id_refl. Defined.
+
+Polymorphic Lemma simplification_sigma1S_nondep_dep@{i j | i <= eq.u0} {A : Type@{i}} 
+  {P : SProp}
+  (p q : A) (x : P) (y : P) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : p = q, B (pack_sigmaS_eq_nondep e')) ->
+  (forall e : sigmaSI (fun _ => P) p x = sigmaSI (fun _ => P) q y, B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  change x with (pr2S (sigmaSI _ p x)) at 2.
+  change y with (pr2S (sigmaSI _ q y)) at 3.
+  destruct e.
+  intros X. simpl in *.
+  apply (X id_refl).
+Defined.
+
 Definition pack_sigma@{i} {A : Type@{i}} {P : A -> Type@{i}} {p q : A} {x : P p} {y : P q}
   (e' : Id p q) (e : Id (@Id_rew A p P x q e') y) : Id (p, x) (q, y).
 Proof. destruct e'. simpl in e. destruct e. apply id_refl. Defined.
@@ -162,6 +208,27 @@ Proof.
   destruct e.
   intros X. simpl in *.
   apply (X id_refl id_refl).
+Defined.
+
+Polymorphic Definition pack_sigmaS_eq@{i |} {A : Type@{i}} {P : A -> SProp} {p q : A} {x : P p} {y : P q}
+  (e' : p = q) : Id (sigmaSI _ p x) (sigmaSI _ q y).
+Proof. destruct e'. apply id_refl. Defined.
+
+Polymorphic Lemma simplification_sigma1S_dep_dep@{i j|}
+  {A : Type@{i}} {P : A -> SProp}
+  (p q : A) (x : P p) (y : P q) {B : sigmaSI _ p x = sigmaSI _ q y -> Type@{j}} :
+  (forall e' : Id p q, B (pack_sigmaS_eq e')) ->
+  (forall e : Id (sigmaSI _ p x) (sigmaSI _ q y), B e).
+Proof.
+  intros. revert X.
+  change p with (pr1S (sigmaSI _ p x)).
+  change q with (pr1S (sigmaSI _ q y)).
+  unfold pack_sigmaS_eq.
+  change x with (pr2S (sigmaSI _ p x)) at 3 5.
+  change y with (pr2S (sigmaSI _ q y)) at 2.
+  destruct e.
+  intros X. simpl in *.
+  apply (X id_refl).
 Defined.
 
 (*  Lemma simplification_sigma1'@{i j} {A : Type@{i}} {P : A -> Type@{i}} {B : Type@{j}} (p q : A) (x : P p) (y : P q) : *)


### PR DESCRIPTION
Also allow simplification of equality involving sigma types of codomain SProp, which naturally appear during pattern-matching. The code should be slightly generalized to support other SProp/Type combinations.

Closes #365