### PR TITLE
Fix issue 445

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -770,8 +770,8 @@ let interp_arity env evd ~poly ~is_rec ~with_evars notations (((loc,i),udecl,rec
   let program_orig_type = it_mkProd_or_LetIn arity sign in
   let program_sort =
     let u = Sorts.univ_of_sort (Retyping.get_sort_of env !evd program_orig_type) in
-    let sigma, sortl, sortu = nonalgebraic_universe_level_of_universe env !evd u in
-    evd := sigma; sortu
+    (* let sigma, sortl, sortu = nonalgebraic_universe_level_of_universe env !evd u in *)
+    ref u
   in
   let program_implicits = Impargs.compute_implicits_with_manual env !evd program_orig_type false impls in
   let () = evd := Evd.minimize_universes !evd in

--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -364,7 +364,7 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in
     let sigma = Proofview.Goal.sigma gl in
-    let sort = Sorts.univ_of_sort (Retyping.get_sort_of env sigma concl) in
+    let sort = ref (Sorts.univ_of_sort (Retyping.get_sort_of env sigma concl)) in
     let env = Environ.reset_context env in
     let hyps = Proofview.Goal.hyps gl in
     let default_loc, id = id in
@@ -460,7 +460,6 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
       let split : Splitting.splitting =
         Covering.covering env evd p data clauses [] prob [] ty
       in
-
       let c, ty =
         Splitting.term_of_tree env evd sort split
       in

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -1105,26 +1105,30 @@ let evd_comb1 f evd x =
 (* Universe related functions *)
 
 let nonalgebraic_universe_level_of_universe env sigma u =
-  match Univ.Universe.level u with
+  match Univ.Universe.level !u with
   | Some l ->
-    if Univ.Level.is_small l then sigma, l, u
+    if Univ.Level.is_small l then sigma, l
     else
       (match Evd.universe_rigidity sigma l with
       | Evd.UnivFlexible true ->
-        Evd.make_nonalgebraic_variable sigma l, l, Univ.Universe.make l
-      | _ -> sigma, l, u)
+        Evd.make_nonalgebraic_variable sigma l, l
+      | _ -> sigma, l)
   | _ ->
     let sigma, l = Evd.new_univ_level_variable Evd.univ_flexible sigma in
+    if !debug then
+      Feedback.msg_debug Pp.(str" generating variable " ++ Univ.Level.pr l);
     let ul = Univ.Universe.make l in
-    let sigma = Evd.set_leq_sort env sigma (Sorts.sort_of_univ u) (Sorts.sort_of_univ ul) in
-    sigma, l, ul
+    let sigma = Evd.set_leq_sort env sigma (Sorts.sort_of_univ !u) (Sorts.sort_of_univ ul) in
+    u := ul;
+    sigma, l
 
 let instance_of env sigma ?argu goalu =
-  let sigma, goall, goalu = nonalgebraic_universe_level_of_universe env sigma goalu in
-  let sigma, goall, goalu =
+  let sigma, goall = nonalgebraic_universe_level_of_universe env sigma goalu in
+  let sigma, goall =
     if Univ.Level.is_prop goall then
-      sigma, Univ.Level.set, Univ.Universe.make Univ.Level.set
-    else sigma, goall, goalu
+      (goalu := Univ.Universe.make Univ.Level.set;
+       sigma, Univ.Level.set)
+    else sigma, goall
   in
   let inst =
     match argu with
@@ -1134,4 +1138,4 @@ let instance_of env sigma ?argu goalu =
       EConstr.EInstance.make (Univ.Instance.of_array (Array.append equarray [| goall |]))
     | None -> EConstr.EInstance.make (Univ.Instance.of_array [| goall |])
   in
-  sigma, inst, goalu
+  sigma, inst

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -460,10 +460,10 @@ val splay_prod_n_assum : env -> Evd.evar_map -> int -> types -> rel_context * ty
 
 (* Universes *)
 val nonalgebraic_universe_level_of_universe :
-  Environ.env -> Evd.evar_map -> Univ.Universe.t -> Evd.evar_map * Univ.Level.t * Univ.Universe.t
+  Environ.env -> Evd.evar_map -> Univ.Universe.t ref -> Evd.evar_map * Univ.Level.t
 val instance_of :
   Environ.env ->
   Evd.evar_map ->
   ?argu:EConstr.EInstance.t ->
-  Univ.Universe.t ->
-  Evd.evar_map * EConstr.EInstance.t * Univ.Universe.t
+  Univ.Universe.t ref ->
+  Evd.evar_map * EConstr.EInstance.t

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -232,7 +232,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
   let sigma, program_sort =
     Evarsolve.refresh_universes ~status:Evd.univ_flexible ~onlyalg:true
       (Some false) env sigma (mkSort program_sort) in
-  let program_sort = Sorts.univ_of_sort (EConstr.ESorts.kind sigma (EConstr.destSort sigma program_sort)) in
+  let program_sort = ref (Sorts.univ_of_sort (EConstr.ESorts.kind sigma (EConstr.destSort sigma program_sort))) in
   let evd = ref sigma in
   let data =
     Covering.{

--- a/src/simplify.mli
+++ b/src/simplify.mli
@@ -15,7 +15,7 @@ and simplification_rule =
   | Infer_many
 and simplification_rules = (Loc.t option * simplification_rule) list
 
-type goal = EConstr.rel_context * EConstr.types * Univ.Universe.t
+type goal = EConstr.rel_context * EConstr.types * Univ.Universe.t ref
 (* The [goal] corresponds to the context and type of an evar representing a
  * hole in the term. *)
 type open_term = (goal * EConstr.existential) option * EConstr.constr

--- a/src/splitting.mli
+++ b/src/splitting.mli
@@ -127,7 +127,7 @@ val helper_evar :
 (** Compilation to Coq terms *)
 val term_of_tree :
   env ->
-  Evd.evar_map ref -> Univ.Universe.t ->
+  Evd.evar_map ref -> Univ.Universe.t ref ->
   splitting ->
   constr * constr
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -316,7 +316,7 @@ type program_info = {
   program_loc : Loc.t;
   program_id : Id.t;
   program_orig_type : EConstr.t; (* The original type *)
-  program_sort : Univ.Universe.t; (* The sort of this type *)
+  program_sort : Univ.Universe.t ref; (* The sort of this type *)
   program_sign : EConstr.rel_context;
   program_arity : EConstr.t;
   program_rec : program_rec_info option;
@@ -331,9 +331,9 @@ let map_universe f u =
   | _ -> assert false
 
 let map_program_info f p =
+  let () = p.program_sort := map_universe f !(p.program_sort) in
   { p with
     program_orig_type = f p.program_orig_type;
-    program_sort = map_universe f p.program_sort;
     program_sign = map_rel_context f p.program_sign;
     program_arity = f p.program_arity }
 

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -151,7 +151,7 @@ type program_info = {
   program_loc : Loc.t;
   program_id : Id.t;
   program_orig_type : EConstr.t; (* The original type *)
-  program_sort : Univ.Universe.t; (* The sort of this type *)
+  program_sort : Univ.Universe.t ref; (* The sort of this type *)
   program_sign : EConstr.rel_context;
   program_arity : EConstr.t;
   program_rec : program_rec_info option;

--- a/test-suite/issues/issue445.v
+++ b/test-suite/issues/issue445.v
@@ -1,0 +1,10 @@
+From Equations Require Import Equations.
+
+Universe u.
+(* Same observed behaviour with and without universe polymorphism set *)
+Set Universe Polymorphism.
+
+Equations foo@{} (u : unit) : Type@{u} :=
+  | tt => unit.
+(* The command has indeed failed with message: *)
+(* Universe {debug.204} is unbound. *)


### PR DESCRIPTION
Lazily compute a universe level for the type of the goal/function to avoid generating an unnecessary dependency when it is not necessary.

Closes #445 