### PR TITLE
Fix issue #279

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -1019,11 +1019,24 @@ let compute_rec_data env evars data lets subst p =
 
 exception UnfaithfulSplit of (Loc.t option * Pp.t)
 
-let rename_domain env sigma bindings (ctx, p, ctx') = 
+
+let rename_away_from away decl =
+  let open Context.Rel.Declaration in 
+  let na = get_name decl in
+  match na with 
+  | Anonymous -> decl
+  | Name id ->
+    if Id.Set.mem id !away then
+      set_name (Name (next_ident_away id away)) decl
+    else decl
+
+let rename_domain env sigma bindings away (ctx, p, ctx') = 
   let fn rel decl = 
     match Int.Map.find rel bindings with
-    | exception Not_found -> decl
-    | (id, _, gen) -> if gen != Generated then Context.Rel.Declaration.set_name (Name id) decl else decl
+    | exception Not_found -> rename_away_from away decl
+    | (id, _, gen) -> 
+      if gen != Generated then Context.Rel.Declaration.set_name (Name id) decl 
+      else rename_away_from away decl
   in 
   let rctx = CList.map_i fn 1 ctx in
   mk_ctx_map env sigma rctx p ctx'
@@ -1086,34 +1099,39 @@ let rec covering_aux env evars p data prev (clauses : (pre_clause * (int * int))
                   pr_pat env !evars pat'))
           in ignore (List.fold_left check Id.Map.empty s)
        in
-       let bindings, s = CList.fold_left (fun (bindings, s) ((loc, x, gen), y) ->
+       let bindings, s, away = CList.fold_left (fun (bindings, s, away) ((loc, x, gen), y) ->
           let pat = 
             match y with
             | PRel i -> Some (i, false)
             | PInac i when isRel !evars i -> Some (destRel !evars i, true)
             | _ -> None 
           in
+          let away =
+            match gen with
+            | Generated -> away 
+            | _ -> Id.Set.add x away
+          in
           match pat with
           | Some (i, inacc) -> begin
             match Int.Map.find i bindings with
-            | exception Not_found -> (Int.Map.add i (x, inacc, gen) bindings, s)
+            | exception Not_found -> (Int.Map.add i (x, inacc, gen) bindings, s, away)
             | (x', inacc', gen') -> begin
               match gen, gen' with
-              | Generated, (User | Implicit) -> (Int.Map.add i (x', inacc && inacc', gen') bindings, s)
-              | Generated, Generated -> (Int.Map.add i (x, inacc && inacc', gen) bindings, s)
-              | _, Generated -> (Int.Map.add i (x, inacc && inacc', gen) bindings, s)
+              | Generated, (User | Implicit) -> (Int.Map.add i (x', inacc && inacc', gen') bindings, s, away)
+              | Generated, Generated -> (Int.Map.add i (x, inacc && inacc', gen) bindings, s, away)
+              | _, Generated -> (Int.Map.add i (x, inacc && inacc', gen) bindings, s, away)
               | _, _ -> 
                 if not (Id.equal x x') then
                   (* We allow aliasing of implicit variable names resulting from forcing a pattern *)
                   if not data.flags.allow_aliases && (gen == User && gen' == User) then
                     user_err_loc (loc, "matches",
                       Pp.(str "The pattern " ++ Id.print x ++ str " should be equal to " ++ Id.print x' ++ str", it is forced by typing"))
-                  else (bindings, (x, y) :: s)
-                else (bindings, s)
+                  else (bindings, (x, y) :: s, away)
+                else (bindings, s, away)
               end
             end
-          | None -> (bindings, (x, y) :: s)) 
-          (Int.Map.empty, []) s
+          | None -> (bindings, (x, y) :: s, away)) 
+          (Int.Map.empty, [], Id.Set.empty) s
            (* @ List.filter_map (fun (x, y) ->
             match DAst.get x with
             | PUVar (id, gen) -> Some ((DAst.with_loc_val (fun ?loc _ -> loc) x, id, gen), PInac y)
@@ -1124,7 +1142,8 @@ let rec covering_aux env evars p data prev (clauses : (pre_clause * (int * int))
           prlist_with_sep spc (fun (i, (x, inacc, gen)) -> str "Rel " ++ int i ++ str" = " ++ 
           pr_provenance ~with_gen:true (Id.print x) gen ++ 
           str", inacc = " ++ bool inacc) (Int.Map.bindings bindings));
-       let prob = rename_domain env !evars bindings prob in
+       let away = ref away in
+       let prob = rename_domain env !evars bindings away prob in
        if !Equations_common.debug then Feedback.msg_debug (str "Renamed problem: " ++ 
         hov 2 (pr_context_map env !evars prob));
        (* let sext =
@@ -1449,6 +1468,8 @@ and interp_clause env evars p data prev clauses' path (ctx,pats,ctx' as prob)
         | UnifSuccess (s, alias) ->
           (* A substitution from the problem variables to user patterns and
              from user pattern variables to patterns instantiating problem variables. *)
+          equations_debug Pp.(fun () -> str"Aliases: " ++ prlist_with_sep (fun () -> str ",") (fun (id,cpat) ->
+            Id.print id ++ str" -> " ++ pr_pat env !evars cpat) alias);
           let newlhs =
             List.map_filter
               (fun i ->

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -62,6 +62,7 @@ issues/issue228.v
 issues/issue246.v
 issues/issue249.v
 issues/issue258.v
+issues/issue279.v
 issues/issue286.v
 issues/issue297.v
 issues/issue306.v

--- a/test-suite/issues/issue279.v
+++ b/test-suite/issues/issue279.v
@@ -1,0 +1,53 @@
+From Equations Require Import Equations.
+Set Equations Transparent.
+
+Module Initial.
+Inductive term :=
+| tBox
+| tConstruct (ind : nat) (c : nat)
+| tConst (kn : nat).
+
+Equations eta_exp_discr (t : term) : Prop :=
+eta_exp_discr (tConstruct ind c) := False;
+eta_exp_discr (tConst kn) := False;
+eta_exp_discr _ := True.
+
+Inductive eta_exp_view : term -> Type :=
+| eta_exp_view_Construct ind c : eta_exp_view (tConstruct ind c)
+| eta_exp_view_Const kn : eta_exp_view (tConst kn)
+| eta_exp_view_other t : eta_exp_discr t -> eta_exp_view t.
+
+Equations eta_exp_viewc (t : term) : eta_exp_view t :=
+eta_exp_viewc (tConstruct ind c) := eta_exp_view_Construct ind c;
+eta_exp_viewc (tConst kn) := eta_exp_view_Const kn;
+eta_exp_viewc t := eta_exp_view_other t _.
+
+Definition decompose_app (t : term) : term * nat := (t, 0).
+
+Definition inspect {A} (a : A) : { x : A | x = a } :=
+  exist _ a eq_refl.
+
+Fail Equations eta_expand (t : term) : nat :=
+eta_expand t with inspect (decompose_app t) := {
+  | exist _ (t', n) _ with eta_exp_viewc t' := {
+    | eta_exp_view_Construct ind c := 0;
+    | eta_exp_view_Const n := n;
+    | eta_exp_view_other t' discr := 0
+    }
+  }.
+End Initial.
+
+Fail Equations eta_expand : nat :=
+eta_expand with 0 :=
+  | n with 5 :=
+    | n := n.
+
+Equations test
+  (n : nat) : nat :=
+  test 1 := 17 ;
+  test n with true := {
+    | true => n
+    | false => 17
+  }.
+    
+Example test' := (eq_refl : test 2 = 2).


### PR DESCRIPTION
One could wrongly capture variables when they are more defined in the programming problem than the pattern (last example of #279).