### PR TITLE
Make eapply_hyp a backtracking tactic

### DIFF
--- a/theories/CoreTactics.v
+++ b/theories/CoreTactics.v
@@ -133,7 +133,7 @@ Ltac destruct_sigma id :=
 Ltac simp_sigmas := repeat destruct_one_sigma ; simpl in *.
 
 Ltac eapply_hyp :=
-  match goal with
+  multimatch goal with
     [ H : _ |- _ ] => eapply H
   end.
 


### PR DESCRIPTION
In case multiple hypotheses can be applied, allow proof search to go through them.