### PR TITLE
Adapt to Coq PR #15565: it_mkLambda & cie on econstr are now in EConstr

### DIFF
--- a/src/eqdec.ml
+++ b/src/eqdec.ml
@@ -19,7 +19,6 @@
 open Util
 open Names
 open Nameops
-open Termops
 open Declarations
 open Inductiveops
 open Vars


### PR DESCRIPTION
As a consequence an `open Termops` becomes useless in `eqdec.ml`.  (`Termops` keeps the variants on `constr`.)

To be merged synchronously with coq/coq#15565.