### PR TITLE
Adapt to Coq PR #16311: call check_evar_instance before defining an evar

### DIFF
--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -94,11 +94,11 @@ let autorewrite_one b =
     match rules with
     | [] -> tclFAIL (str"Couldn't rewrite")
     | r :: rules ->
-       let global, _univs = Constr.destRef r.Autorewrite.rew_lemma in
+       let global, _univs = Constr.destRef (snd @@ Autorewrite.RewRule.rew_lemma r) in
        let tac =
          Proofview.tclBIND
          (pf_constr_of_global global)
-         (if r.Autorewrite.rew_l2r then Equality.rewriteLR else Equality.rewriteRL)
+         (if (Autorewrite.RewRule.rew_l2r r) then Equality.rewriteLR else Equality.rewriteRL)
        in
        Proofview.tclOR tac
          (fun e -> if !debug then Feedback.msg_debug (str"failed"); aux rules)

--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -415,8 +415,8 @@ let compose_term (env : Environ.env) (evd : Evd.evar_map ref)
         EConstr.mkVar id) named_ctx1 in
       (* Finally, substitute the rels in [c2] to get a valid term for [ev1]. *)
       let c2 = Vars.substl subst_ctx1 c2 in
-      evd := Evd.define ev1 c2 !evd;
       evd := Evarsolve.check_evar_instance Evarconv.(conv_fun evar_conv_x) unif_flags env !evd ev1 c2;
+      evd := Evd.define ev1 c2 !evd;
       h2, c1
   | None -> assert false
 


### PR DESCRIPTION
To fix coq/coq#16303, we enforce the stronger invariant on Evarsolve.check_evar_instance that the evar is not yet defined at the time we check the well-typing of its instance.

This PR enforces the invariant in Coq-Equations too.

At first view, it is backward-compatible and can be merged as soon as now.