### PR TITLE
Remove Makefile.hott.local, since hott collides HoTT on macOS

### DIFF
--- a/Makefile.hott.local
+++ b/Makefile.hott.local
@@ -1,1 +1,0 @@
-CAMLPKGS+=-package coq-core.plugins.extraction,coq-core.plugins.cc


### PR DESCRIPTION
Fixes #492