### PR TITLE
Adapt to coq/coq#17038 (drop -rectypes flag as coq_makefile default)

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,2 +1,3 @@
 CAMLPKGS+=-package coq-core.plugins.extraction,coq-core.plugins.cc
+CAMLFLAGS+=-rectypes
 ci: all test-suite examples


### PR DESCRIPTION
Coq no longer depends on being compiled with the `-rectypes` flag, but this project does, so add flag explicitly. Should be backwards compatible.