### PR TITLE
Adapt to coq/coq#17098 (functional grammar state)

### DIFF
--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -253,7 +253,7 @@ open Pcoq
 open Constr
 open Syntax
 
-let _ = CLexer.add_keyword "λ"
+let () = Pcoq.set_keyword_state (CLexer.add_keyword (Pcoq.get_keyword_state()) "λ")
 
 let check_eqns_ident =
   let open Pcoq.Lookahead in


### PR DESCRIPTION
Why is this add_keyword necessary, shouldn't grammar extend do it automatically?