### PR TITLE
Workaround to a completely crazy handling of universe contexts.

### DIFF
--- a/src/equations.ml
+++ b/src/equations.ml
@@ -86,6 +86,7 @@ let define_unfolding_eq ~pm env evd flags p unfp prog prog' ei hook =
   let subproofs = Principles_proofs.extract_subprograms env evd ei.equations_where_map p unfp in
   let fold pm (name, subst, uctx, typ) =
     let typ = EConstr.Unsafe.to_constr typ in
+    let typ = collapse_term_qualities uctx typ in
     let tac = Principles_proofs.prove_unfolding_sublemma info ei.equations_where_map prog.program_cst funf_cst subst in
     let cinfo = Declare.CInfo.make ~name ~typ () in
     let info = Declare.Info.make ~poly:info.poly
@@ -101,7 +102,8 @@ let define_unfolding_eq ~pm env evd flags p unfp prog prog' ei hook =
     Principles_proofs.(prove_unfolding_lemma info ei.equations_where_map prog.program_cst funf_cst
       p unfp)
   in
-  let cinfo = Declare.CInfo.make ~name:unfold_eq_id ~typ:(to_constr evd stmt) ~impargs:(program_impls p) () in
+  let stmt = collapse_term_qualities (Evd.evar_universe_context evd) (EConstr.to_constr evd stmt) in
+  let cinfo = Declare.CInfo.make ~name:unfold_eq_id ~typ:stmt ~impargs:(program_impls p) () in
   let info = Declare.Info.make ~poly:info.poly
       ~scope:info.scope
       ~kind:(Decls.IsDefinition info.decl_kind)

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -449,3 +449,6 @@ val instance_of :
   ?argu:EConstr.EInstance.t ->
   ESorts.t ->
   Evd.evar_map * EConstr.EInstance.t * ESorts.t
+
+val collapse_term_qualities : UState.t -> Constr.t -> Constr.t
+(* Hack to prevent sending terms with unbound qualities to the kernel *)

--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -332,6 +332,7 @@ let aux_ind_fun info chop nested unfp unfids p =
           let program_tac =
             tclTHEN fixtac (aux chop None [] prog.program_splitting)
           in
+          let ty = EConstr.of_constr @@ collapse_term_qualities (Evd.evar_universe_context sigma) (EConstr.to_constr sigma ty) in
           tclTHEN (assert_by (Name (program_id prog)) ty program_tac)
             (observe "solving nested premises of compute rule"
               (solve_ind_rec_tac info.term_info))
@@ -585,7 +586,9 @@ let aux_ind_fun info chop nested unfp unfids p =
               let rels = extended_rel_list 0 ctx in
               let indargs = List.append indargs rels in
               let app = applistc ind (List.append indargs [applistc where_term rels]) in
-              it_mkProd_or_LetIn app ctx
+              let ty = it_mkProd_or_LetIn app ctx in
+              let ty = EConstr.of_constr @@ collapse_term_qualities UState.empty (EConstr.Unsafe.to_constr ty) in
+              ty
             in
             let tac =
               tclTHEN acc


### PR DESCRIPTION
Since the Program (and thus Equations) API is relying on a bunch of hacks to handle universe constraints, this results in Equation haphazardly performing evarmap surgery to make things go through. Unfortunately with the arrival of sort qualities, many hacks are not working anymore as the plugin sends unbound qualities to the kernel, which is now an anomaly.

Instead of trying to fix the utterly nonsensical evarmap threading, which would be a daunting task of its own, we hack around the Program code to ensure we never define terms with unresolved qualities. Basically, we intercept terms sent to the kernel and fix their relevance by hand. This is not very satisfying but at least it is a quick hack to make progress on the SProp front of Coq.