### PR TITLE
Fix relevance computation in various places.

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -920,8 +920,8 @@ let named_of_rel_context ?(keeplets = false) default l =
     List.fold_right
       (fun decl (subst, args, ids, ctx) ->
         let decl = Context.Rel.Declaration.map_constr (substl subst) decl in
-	let id = match get_name decl with Anonymous -> default () | Name id -> id in
-        let d = Named.Declaration.of_tuple (annotR id, get_value decl, get_type decl) in
+    let id = match get_name decl with Anonymous -> default () | Name id -> id in
+    let d = Named.Declaration.of_rel_decl (fun _ -> id) decl in
 	let args = if keeplets ||Context.Rel.Declaration.is_local_assum decl then mkVar id :: args else args in
 	  (mkVar id :: subst, args, id :: ids, d :: ctx))
       l ([], [], [], [])

--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -375,7 +375,7 @@ let define_mutual_nested env evd get_prog progs =
       in
       let after = (nested - 1) - before in
       let fixb = (Array.make 1 idx, 0) in
-      let fixna = Array.make 1 (nameR p.program_id) in
+      let fixna = Array.make 1 (make_annot (Name p.program_id) (Retyping.relevance_of_sort (ESorts.make p.program_sort))) in
       let fixty = Array.make 1 (Syntax.program_type p) in
       (* Apply to itself *)
       let beforeargs = Termops.rel_list (signlen + 1) before in
@@ -818,7 +818,7 @@ let change_lhs s (l, p, r) =
   let l' =
     List.map
       (function LocalDef ({binder_name=Name id}, b, t) as decl ->
-         (try let b' = List.assoc id s in LocalDef (nameR id, b', t)
+         (try let b' = List.assoc id s in LocalDef (make_annot (Name id) (get_relevance decl), b', t)
           with Not_found -> decl)
               | decl -> decl) l
   in l', p, r

--- a/test-suite/issues/issue354.v
+++ b/test-suite/issues/issue354.v
@@ -4,6 +4,8 @@ From Equations Require Import Equations.
 Inductive Ssig {A : Type} (P : A -> SProp) :=
   | Sexists (a : A) (b : P a) : Ssig P.
 
+Set Warnings "+bad-relevance".
+
 Equations Spr1 {A : Type} {P : A -> SProp} (s : Ssig P) : A :=
   Spr1 (Sexists _ a b) := a.
 


### PR DESCRIPTION
This is enough to fix the relevance issues in the only test that uses SProp. There are still other places where this is broken but since the interesection of Equations with SProp users is currently empty I will defer the patches to when it matters.