### PR TITLE
Synchronize set_strategy with the discharge/load infrastructure

### DIFF
--- a/src/equations.ml
+++ b/src/equations.ml
@@ -45,7 +45,7 @@ let define_unfolding_eq ~pm env evd flags p unfp prog prog' ei hook =
   let funfc = e_new_global evd info'.term_id in
   let unfold_eq_id = add_suffix (program_id unfp) "_eq" in
   let hook_eqs _ pm =
-    Global.set_strategy (ConstKey funf_cst) Conv_oracle.transparent;
+    Redexpr.set_strategy false [Conv_oracle.transparent, [EvalConstRef funf_cst]];
     let () = (* Declare the subproofs of unfolding for where as rewrite rules *)
       let decl _ (_, id, _) =
         let gr =

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -268,7 +268,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
      * let _fixprots = [s] in *)
     (* let () = Equations.define_principles flags None fixprots [proginfo, compiled_info] in *)
     (* The principles are now shown, let's prove this forms an equivalence *)
-    Global.set_strategy (ConstKey program_cst) Conv_oracle.transparent;
+    Redexpr.set_strategy false [Conv_oracle.transparent,[EvalConstRef program_cst]];
     let env = Global.env () in
     let sigma = Evd.from_env env in
     let sigma, indu = Evd.fresh_global

--- a/src/principles.ml
+++ b/src/principles.ml
@@ -68,24 +68,6 @@ let inRewRule =
 
 let add_rew_rule ~l2r ~base ref = Lib.add_leaf (inRewRule (base,ref,l2r))
 
-let cache_opacity cst =
-  Global.set_strategy (ConstKey cst) Conv_oracle.Opaque
-
-let subst_opacity (subst, cst) =
-  let gr' = Mod_subst.subst_constant subst cst in
-  gr'
-
-let inOpacity =
-  let open Libobject in
-  let obj =
-    (* We allow discharging rewrite rules *)
-    superglobal_object "EQUATIONS_OPACITY"
-      ~cache:cache_opacity
-      ~subst:(Some subst_opacity)
-      ~discharge:(fun x -> Some x)
-  in
-  declare_object @@ obj
-
 let match_arguments sigma l l' =
   let rec aux i =
     if i < Array.length l' then
@@ -1369,19 +1351,11 @@ let declare_funind ~pm info alias env evd is_rec protos progs
     let instid = Nameops.add_prefix "FunctionalInduction_" id in
     ignore(Equations_common.declare_instance instid ~poly evd [] cl args);
     (* If desired the definitions should be made transparent again. *)
-    begin
-    if !Equations_common.equations_transparent then
-      (Global.set_strategy (ConstKey (fst (destConst evd f))) Conv_oracle.transparent;
-       match alias with
+    let opacity = if !Equations_common.equations_transparent then Conv_oracle.transparent else Conv_oracle.Opaque in
+    Redexpr.set_strategy false [opacity,[EvalConstRef (fst (destConst evd f))]];
+    (match alias with
        | None -> ()
-       | Some ((f, _), _, _) -> Global.set_strategy (ConstKey (fst (destConst evd f))) Conv_oracle.transparent)
-    else
-      ((* Otherwise we turn them opaque and let that information be discharged as well *)
-        Lib.add_leaf (inOpacity (fst (destConst evd f)));
-        match alias with
-        | None -> ()
-        | Some ((f, _), _, _) -> Lib.add_leaf (inOpacity (fst (destConst evd f))))
-    end;
+       | Some ((f, _), _, _) -> Redexpr.set_strategy false [opacity,[EvalConstRef (fst (destConst evd f))]]);
     pm
   in
   let evm, stmtt = Typing.type_of (Global.env ()) !evd statement in
@@ -1771,9 +1745,9 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
               let cst' = fst (destConst !evd f) in
               Hints.(add_hints ~locality [info.base_id]
                 (HintsTransparencyEntry (HintsReferences [Tacred.EvalConstRef cst'], false)));
-              Global.set_strategy (ConstKey cst') Conv_oracle.Opaque
+              Redexpr.set_strategy false [Conv_oracle.Opaque,[EvalConstRef cst']];
            | None -> ());
-          Global.set_strategy (ConstKey cst) Conv_oracle.Opaque;
+          Redexpr.set_strategy false [Conv_oracle.Opaque,[EvalConstRef cst]];
           if with_ind then (declare_ind (); pm) else pm)
         else pm
       in


### PR DESCRIPTION
To register the opacity of lemmas generated by equations, the current code, except for issue #83, directly calls `Safe_typing.set_strategy`. This PR synchronizes the occurrences of `Safe_typing.set_strategy` corresponding to the registration of a constant with the discharge/load mechanism, and, suspectingly, this would solve other issues similar to #83 for other kinds of registered lemmas.

Additionally, the PR would be necessary to eventually go in the direction of PR coq/coq#17888 (discharge on the fly).

If I'm correct, that's the occurrences in `noconf_hom.ml`, `equations.ml`, and `principles.ml`, but not the ones in `principles_proofs.ml`

As for the first `Safe_typing.set_strategy` in `principles.ml` used in the `inOpacity` object, I believe that the `EQUATIONS_OPACITY` object can directly be replaced by Coq's `STRATEGY` object which already plays the same purpose.

