### PR TITLE
Fix synterp-time calls to Nametab

### DIFF
--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -414,14 +414,14 @@ let interp_attrs (elim, eqns) =
 VERNAC COMMAND EXTEND Define_equations_refine CLASSIFIED BY { classify_equations }
 | #[ poly = polymorphic; program_mode = program; atts = derive_flags; tactic = equations_tactic ] ![program_interactive] 
   [ "Equations" "?" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations_interactive ~poly ~program_mode ?tactic
+    { fun ~pm -> Equations.equations_interactive ~pm ~poly ~program_mode ?tactic
       (List.append opt (interp_attrs atts)) (fst eqns) (snd eqns) }
 END
 
 VERNAC COMMAND EXTEND Define_equations CLASSIFIED AS SIDEFF STATE program
 | #[ poly = polymorphic; program_mode = program; atts = derive_flags; tactic = equations_tactic  ] 
   [ "Equations" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations ~poly ~program_mode ?tactic
+    { fun ~pm -> Equations.equations ~pm ~poly ~program_mode ?tactic
       (List.append opt (interp_attrs atts)) (fst eqns) (snd eqns) }
 END
 
@@ -533,11 +533,11 @@ END
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED AS SIDEFF STATE program
 | #[ poly = polymorphic ] [ "Derive" ne_ident_list(ds) "for" global_list(c) ] -> {
-  Ederive.derive ~poly (List.map Id.to_string ds)
+  fun ~pm -> Ederive.derive ~pm ~poly (List.map Id.to_string ds)
     (List.map (fun x -> x.CAst.loc, Smartlocate.global_with_alias x) c)
   }
 | #[ poly = polymorphic ] [ "Equations" "Derive" ne_ident_list(ds) "for" global_list(c) ] -> {
-  Ederive.derive ~poly (List.map Id.to_string ds)
+  fun ~pm -> Ederive.derive ~pm ~poly (List.map Id.to_string ds)
     (List.map (fun x -> x.CAst.loc, Smartlocate.global_with_alias x) c)
   }
 END


### PR DESCRIPTION
Due to partial application in VERNAC EXTEND rules, some calls to Nametab where executed at synterp time (before Nametab is available on non-module objects).

This issue made Equations unusable with VsCoq.