### PR TITLE
Remove a useless evar normalization in Equations.define_by_eqs.

### DIFF
--- a/src/equations.mli
+++ b/src/equations.mli
@@ -26,7 +26,6 @@ val define_principles :
   pm:Declare.OblState.t ->
   flags ->
   Syntax.rec_type ->
-  EConstr.t list ->
   (program * compiled_program_info) list -> Declare.OblState.t
 
 val equations :


### PR DESCRIPTION
We actually only care about the relevance of the fixpoints being defined. Evar normalization was performed w.r.t. a completely broken evarmap that would miss potential evars in the terms, forcing nf_evar to silently ignore (and mishandle) undefined evars.