### PR TITLE
Adapt to Coq PR #18743: search_guard is now able to decide late if a recursive definition is a fix or a cofix

### DIFF
--- a/src/splitting.ml
+++ b/src/splitting.ml
@@ -449,7 +449,7 @@ let define_mutual_nested env evd get_prog progs =
     let possible_indexes =
       Array.map3 (compute_possible_guardness_evidences !evd) structargs bodies tys
     in
-    Pretyping.esearch_guard env !evd (Array.to_list possible_indexes)
+    Pretyping.esearch_fix_guard env !evd (Array.to_list possible_indexes)
       (names, tys, bodies)
   in
   let declare_fix_fns i (p,prog) =


### PR DESCRIPTION
To be kept synchronous with coq/coq#18743.