### PR TITLE
Centralize the use of Tactics.assert_before_replacing.

### DIFF
--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -356,8 +356,7 @@ let specialize_eqs ?with_block id =
   let ty = Evarutil.nf_evar !evars ty in
   let acc = Evarutil.nf_evar !evars acc in
     if worked then
-      tclTHENFIRST (Tactics.assert_before_replacing id ty)
-        (exact_no_check acc)
+      assert_replacing id acc ty
     else tclFAIL (str "Nothing to do in hypothesis " ++ Id.print id ++
                     Printer.pr_econstr_env env !evars ty
                    )

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -855,6 +855,9 @@ let move_after_deps id c =
     Tactics.move_hyp id (Logic.MoveAfter first)
   in Proofview.Goal.enter enter
 
+let assert_replacing id c ty =
+  tclTHENFIRST (assert_before_replacing id ty) (exact_no_check c)
+
 let observe s (tac : unit Proofview.tactic) =
   let open Proofview.Notations in
   let open Proofview in

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -341,6 +341,7 @@ val ident_of_smart_global :
   Libnames.qualid Constrexpr.or_by_notation -> Id.t
 
 val move_after_deps : Names.Id.t -> constr -> unit Proofview.tactic
+val assert_replacing : Names.Id.t -> constr -> types -> unit Proofview.tactic
 
 val extended_rel_vect : int -> rel_context -> constr array
 val extended_rel_list : int -> rel_context -> constr list

--- a/src/sigma_types.ml
+++ b/src/sigma_types.ml
@@ -857,8 +857,7 @@ module Tactics =struct
              let newprf = Vars.replace_vars sigma [(id,b)] prf in
              tclTHEN (clear [id]) (Tactics.letin_tac None (Name id) newprf (Some typ) nowhere)
           | None ->
-             (tclTHENFIRST (assert_before_replacing id typ)
-                           (Tactics.exact_no_check prf)))
+             assert_replacing id prf typ)
       | None -> tclFAIL (str"No currying to do in " ++ Id.print id)
   end
 


### PR DESCRIPTION
Trivial cleanup.