### PR TITLE
Adapt w.r.t. coq/coq#19120.

### DIFF
--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -801,7 +801,6 @@ let e_conv env evdref t t' =
   match Reductionops.infer_conv env !evdref ~pb:Conversion.CONV t t' with
   | Some sigma -> (evdref := sigma; true)
   | None -> false
-  | exception Conversion.NotConvertible -> false
       
 let deps_of_var sigma id env =
   Environ.fold_named_context


### PR DESCRIPTION
This is backwards compatible because the infer_conv function is *never* supposed to fail with the NotConvertible exception even on master.