### PR TITLE
Adapt w.r.t. coq/coq#20278.

### DIFF
--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -339,7 +339,7 @@ let specialize_eqs ?with_block id =
            (* aux in_block false ctx (make_def na None t :: subst) (mkApp (lift 1 acc, [| mkRel 1 |])) b *)
            acc, in_eqs, ctx, subst, ty
          else
-           let e = evd_comb1 (Evarutil.new_evar env') evars t in
+           let e = evd_comb1 (Evarutil.new_evar ~typeclass_candidate:false env') evars t in
            aux block_count in_block false ctx (make_def na (Some e) t :: subst) (mkApp (lift 1 acc, [| mkRel 1 |])) b)
     | t -> acc, in_eqs, ctx, subst, ty
   in

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -158,13 +158,6 @@ let typecheck_rel_context env evd ctx =
                    (Printexc.to_string e);
     raise e
 
-let new_untyped_evar () =
-  let (sigma, ev) =
-    new_pure_evar empty_named_context_val Evd.empty ~relevance:EConstr.ERelevance.relevant
-      (EConstr.of_constr mkProp)
-  in
-  ev
-
 let proper_tails l = snd (List.fold_right (fun _ (t,ts) -> List.tl t, ts @ [t]) l (l, []))
 
 let list_find_map_i f =
@@ -1039,7 +1032,7 @@ let nf_betadeltaiota = nf_all
 let anomaly ?label pp = CErrors.anomaly ?label pp
 
 let new_evar env evm ?src ty =
-  Evarutil.new_evar env evm ?src ty
+  Evarutil.new_evar ~typeclass_candidate:true env evm ?src ty
 
 let new_type_evar env evm ?src rigid =
   Evarutil.new_type_evar env evm rigid ?src

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -83,9 +83,6 @@ val lift_rel_context : int -> rel_context -> rel_context
 val lift_list : constr list -> constr list
 val lift_constrs : int -> constr list -> constr list
 
-(** Evars *)
-val new_untyped_evar : unit -> Evar.t
-
 (** Checking *)
 val check_term :
   Environ.env -> Evd.evar_map -> constr -> types -> unit

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -83,7 +83,7 @@ let derive_noConfusion_package ~pm env sigma ~poly (ind,u as indu) indid ~prefix
   let rec term sigma c ty =
     match kind sigma ty with
     | Prod (na, t, ty) ->
-       let sigma, arg = Evarutil.new_evar env sigma t in
+       let sigma, arg = Evarutil.new_evar ~typeclass_candidate:true env sigma t in
        term sigma (mkApp (c, [|arg|])) (subst1 arg ty)
     | _ -> sigma, c, ty
   in

--- a/src/principles_proofs.ml
+++ b/src/principles_proofs.ml
@@ -114,7 +114,7 @@ let revert_last =
 let rec mk_holes env sigma = function
 | [] -> (sigma, [])
 | arg :: rem ->
-  let (sigma, arg) = Evarutil.new_evar env sigma arg in
+  let (sigma, arg) = Evarutil.new_evar ~typeclass_candidate:false env sigma arg in
   let (sigma, rem) = mk_holes env sigma rem in
   (sigma, arg :: rem)
 

--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -329,7 +329,7 @@ let build_term_core (env : Environ.env) (evd : Evd.evar_map ref)
   let tev =
     let (ctx', ty', u') = ngl in
     let env = push_rel_context ctx' env in
-    Equations_common.evd_comb1 (Evarutil.new_evar env) evd ty'
+    Equations_common.evd_comb1 (Evarutil.new_evar ~typeclass_candidate:false env) evd ty'
   in
   let c = f tev in
   let ev = EConstr.destEvar !evd tev in

--- a/src/subterm.ml
+++ b/src/subterm.ml
@@ -245,7 +245,7 @@ let derive_subterm ~pm env sigma ~poly (ind, u as indu) =
       let env' = push_rel_context pars env in
       let evar =
         let evt = (mkApp (get_efresh logic_wellfounded evm, [| ty; relation |])) in
-        evd_comb1 (Evarutil.new_evar env') evm evt
+        evd_comb1 (Evarutil.new_evar ~typeclass_candidate:false env') evm evt
       in
       let b, t = instance_constructor !evm kl [ ty; relation; evar ] in
       (pars, b, t)


### PR DESCRIPTION
Should be backwards compatible, although I did pick non-canonically the default candidate true for the generic wrapper function new_evar.