### PR TITLE
Rely on algebraic errors in Simplify rather than upfront printing.

### DIFF
--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -1331,9 +1331,8 @@ and simplify_one ((loc, rule) : Loc.t option * simplification_rule) :
   let handle_error f =
     SimpFun.make ~name:"handle_error" begin fun env evd gl ->
       try SimpFun.apply f env evd gl
-      with CannotSimplify err ->
-        let err = explain_simplification_error err in (* TODO: probably inefficient, we could try not to wrap it *)
-        Equations_common.user_err_loc (loc, err)
+      with CannotSimplify err as exn ->
+        Loc.raise ?loc exn
     end
   in
   let wrap get_step =

--- a/src/simplify.mli
+++ b/src/simplify.mli
@@ -20,7 +20,8 @@ type goal = EConstr.rel_context * EConstr.types * EConstr.ESorts.t
  * hole in the term. *)
 type open_term = (goal * EConstr.existential) option * EConstr.constr
 
-exception CannotSimplify of Pp.t
+type simplification_error
+exception CannotSimplify of simplification_error
 
 (* TODO Move the context_map inside the open_term... *)
 type simplification_fun


### PR DESCRIPTION
This allows delaying the printing until the error actually reaches the user. This is a source of slowdown observed in Metacoq.