### PR TITLE
Stop pushing proof-local qualities in the global environment.

### DIFF
--- a/src/principles.ml
+++ b/src/principles.ml
@@ -1758,9 +1758,9 @@ let build_equations ~pm with_ind env evd ?(alias:alias option) rec_info progs =
     if not (PolyFlags.univ_poly poly) then
       (* Declare the universe context necessary to typecheck the following
           definitions once and for all. *)
-      let uctx = Evd.sort_context_set !evd in
-      let (qs, us), (qcst, ucst) = uctx in
-      let () = Global.push_qualities ~rigid:false (qs, qcst) in (* XXX *)
+      let sigma = Evd.collapse_sort_variables !evd in
+      let uctx = Evd.sort_context_set sigma in
+      let (_qs, us), (_qcst, ucst) = uctx in
       let () = Global.push_context_set (us, ucst) in
       evd := Evd.from_env (Global.env ())
     else ()


### PR DESCRIPTION
In monomorphic mode, we should basically never add qualities to the environment. The code was thus clearly incorrect. The new code does not make much more sense since the collapsed evarmap is immediately dropped, but at least we are not messing with the global state anymore.