### PR TITLE
Share typing of mutual definitions.

### DIFF
--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -159,6 +159,7 @@ val make_definition :
    even in the polymorphic case. *)
 
 val declare_constant :
+  ?check:bool ->
   Id.t ->
   constr ->
   constr option ->
@@ -166,6 +167,12 @@ val declare_constant :
   kind:Decls.logical_kind ->
   Evd.evar_map ->
   Constant.t * (Evd.evar_map * EConstr.t)
+
+val declare_mutual :
+  poly:PolyFlags.t ->
+  'a Syntax.mutual_fix ->
+  Evd.evar_map ->
+  Evd.evar_map * (Syntax.program_info * 'a * EConstr.t) list
 
 val declare_instance :
   Names.Id.t ->

--- a/src/splitting.mli
+++ b/src/splitting.mli
@@ -198,7 +198,7 @@ val define_mutual_nested : Environ.env ->
   Evd.evar_map ref ->
   ('a -> EConstr.t) ->
   (program_info * 'a) list ->
-  (program_info * 'a * EConstr.t) list *
+  'a mutual_fix *
   (program_info * 'a * EConstr.constr) list
 
 val define_mutual_nested_csts :

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -10,7 +10,6 @@ open Constr
 open Environ
 open Evd
 open Names
-open Equations_common
 
 type 'a with_loc = Loc.t option * 'a
 
@@ -83,7 +82,7 @@ and ('a, 'b) by_annot =
 and 'a where_clause = pre_prototype * 'a list
 and 'a wheres = 'a where_clause list * Vernacexpr.notation_declaration list
 type program = (signature * clause list) list
-and signature = identifier * rel_context * constr (* f : Π Δ. τ *)
+and signature = identifier * EConstr.rel_context * constr (* f : Π Δ. τ *)
 and clause = Clause of Loc.t option * lhs * (clause, clause) rhs (* lhs rhs *)
 
 type pre_equation = Pre_equation of Constrexpr.constr_expr input_pats * (pre_equation, pre_equation) rhs
@@ -158,6 +157,8 @@ type program_info = {
   program_impls : Impargs.manual_implicits;
   program_implicits : Impargs.implicit_status list;
 }
+
+type 'a mutual_fix = MutFix of (program_info * 'a) list * int array * EConstr.rec_declaration
 
 val program_type : program_info -> EConstr.t
 


### PR DESCRIPTION
We know that all definitions from a mutual block are the same except for the index of the fixpoint. In order to avoid a costly type-checking, we just type-check the first entry of a mutual block.