### PR TITLE
Add new attribute [obligations] and global [Set Equations Obligations]

### DIFF
--- a/src/depelim.ml
+++ b/src/depelim.ml
@@ -442,7 +442,7 @@ let dependent_elim_tac ?patterns id : unit Proofview.tactic =
     let data =
       Covering.{
         rec_type = [None];
-        flags = { poly = PolyFlags.of_univ_poly true; open_proof = false; with_eqns = false; with_ind = false;
+        flags = { poly = PolyFlags.of_univ_poly true; obligations = false; open_proof = false; with_eqns = false; with_ind = false;
           allow_aliases = false;
           tactic = !Declare.Obls.default_tactic};
         program_mode = false;

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -146,7 +146,7 @@ let define_principles ~pm (flags : flags) rec_type progs =
     in
     build_equations ~pm flags.with_ind env !evd rec_type splits
 
-let define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof opts eqs nt =
+let define_by_eqs ~pm ~poly ~program_mode ~obligations ~tactic ~open_proof opts eqs nt =
   let with_eqns, with_ind =
     let try_bool_opt opt default =
       try List.assoc opt opts
@@ -157,9 +157,14 @@ let define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof opts eqs nt =
       with_eqns, try_bool_opt OInd !Equations_common.equations_derive_eliminator
     else false, false
   in
+  let obligations =
+    match obligations with
+    | Some b -> b
+    | None -> Equations_common.equations_obligations () || program_mode
+  in
   let env = Global.env () in
-  let flags = { poly; with_eqns; with_ind; allow_aliases = false;
-    tactic; open_proof } in
+  let flags = { poly; obligations; open_proof; with_eqns; with_ind; allow_aliases = false;
+    tactic } in
   let evm, udecl =
     match eqs with
     | (((loc, i), udecl, _, _, _, _), _) :: _ ->
@@ -222,20 +227,20 @@ let interp_tactic = function
     Tacinterp.Value.apply tacval []
   | None -> !Declare.Obls.default_tactic
 
-let equations ~pm ~poly ~program_mode ?tactic opts eqs nt =
+let equations ~pm ~poly ~program_mode ?obligations ?tactic opts eqs nt =
   List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ?loc i) false "def") eqs;
   let tactic = interp_tactic tactic in
   let pm, pstate =
-    define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof:false opts eqs nt in
+    define_by_eqs ~pm ~poly ~program_mode ~obligations ~tactic ~open_proof:false opts eqs nt in
   match pstate with
   | None -> pm
   | Some _ ->
     CErrors.anomaly Pp.(str"Equation.equations leaving a proof open")
 
-let equations_interactive ~pm ~poly ~program_mode ?tactic opts eqs nt =
+let equations_interactive ~pm ~poly ~program_mode ?obligations ?tactic opts eqs nt =
   List.iter (fun (((loc, i), _udecl, nested, l, t, by),eqs) -> Dumpglob.dump_definition CAst.(make ?loc i) false "def") eqs;
   let tactic = interp_tactic tactic in
-  let pm, lemma = define_by_eqs ~pm ~poly ~program_mode ~tactic ~open_proof:true opts eqs nt in
+  let pm, lemma = define_by_eqs ~pm ~poly ~program_mode ~obligations ~tactic ~open_proof:true opts eqs nt in
   match lemma with
   | None ->
     CErrors.anomaly Pp.(str"Equation.equations_interactive not opening a proof")

--- a/src/equations.mli
+++ b/src/equations.mli
@@ -15,6 +15,7 @@ val define_by_eqs
   :  pm:Declare.OblState.t
   -> poly:PolyFlags.t
   -> program_mode:bool
+  -> obligations:bool option
   -> tactic:unit Proofview.tactic
   -> open_proof:bool
   -> Syntax.equation_options
@@ -30,7 +31,10 @@ val define_principles :
 
 val equations :
   pm:Declare.OblState.t ->
-  poly:PolyFlags.t -> program_mode:bool -> ?tactic:Libnames.qualid ->
+  poly:PolyFlags.t ->
+  program_mode:bool ->
+  ?obligations:bool ->
+  ?tactic:Libnames.qualid ->
   Syntax.equation_options ->
   Syntax.pre_equations ->
   Vernacexpr.notation_declaration list ->
@@ -38,7 +42,9 @@ val equations :
 
 val equations_interactive :
   pm:Declare.OblState.t ->
-  poly:PolyFlags.t -> program_mode:bool -> ?tactic:Libnames.qualid ->
+  poly:PolyFlags.t -> program_mode:bool ->
+  ?obligations:bool ->
+  ?tactic:Libnames.qualid ->
   Syntax.equation_options ->
   Syntax.pre_equations ->
   Vernacexpr.notation_declaration list ->

--- a/src/equations_common.ml
+++ b/src/equations_common.ml
@@ -103,6 +103,12 @@ let _ = Goptions.declare_bool_option {
   Goptions.optwrite = (fun b -> equations_derive_eliminator := b)
 }
 
+let { Goptions.get = equations_obligations } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Equations";"Obligations"]
+    ~value:false
+    ()
+
 (* Debugging infrastructure. *)
 
 let debug = ref false
@@ -128,6 +134,7 @@ let ppenv_sigma f =
 
 type flags = {
   poly : PolyFlags.t;
+  obligations : bool;
   open_proof : bool;
   with_eqns : bool;
   with_ind : bool;

--- a/src/equations_common.mli
+++ b/src/equations_common.mli
@@ -19,6 +19,7 @@ val equations_with_funext : bool ref
 val equations_transparent : bool ref
 val equations_derive_equations : bool ref
 val equations_derive_eliminator : bool ref
+val equations_obligations : unit -> bool
 
 val debug : bool ref
 val equations_debug : (unit -> Pp.t) -> unit
@@ -32,6 +33,7 @@ val enter_goal : (Environ.env -> Evd.evar_map -> EConstr.t -> unit Proofview.tac
 (* Common flags *)
 type flags = {
   poly : PolyFlags.t;
+  obligations : bool;
   open_proof : bool;
   with_eqns : bool;
   with_ind : bool;

--- a/src/g_equations.mlg
+++ b/src/g_equations.mlg
@@ -412,16 +412,16 @@ let interp_attrs (elim, eqns) =
 }
 
 VERNAC COMMAND EXTEND Define_equations_refine CLASSIFIED BY { classify_equations }
-| #[ poly = poly_def; program_mode = program; atts = derive_flags; tactic = equations_tactic ] ![program_interactive] 
+| #[ poly = poly_def; program_mode = program; atts = derive_flags; obligations = equations_obligations; tactic = equations_tactic ] ![program_interactive]
   [ "Equations" "?" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations_interactive ~poly ~program_mode ?tactic
+    { Equations.equations_interactive ~poly ~program_mode ?obligations ?tactic
       (List.append opt (interp_attrs atts)) (fst eqns) (snd eqns) }
 END
 
 VERNAC COMMAND EXTEND Define_equations CLASSIFIED AS SIDEFF STATE program
-| #[ poly = poly_def; program_mode = program; atts = derive_flags; tactic = equations_tactic  ] 
+| #[ poly = poly_def; program_mode = program; atts = derive_flags; obligations = equations_obligations; tactic = equations_tactic  ]
   [ "Equations" equation_options(opt) equations(eqns) ] ->
-    { Equations.equations ~poly ~program_mode ?tactic
+    { Equations.equations ~poly ~program_mode ?obligations ?tactic
       (List.append opt (interp_attrs atts)) (fst eqns) (snd eqns) }
 END
 

--- a/src/noconf_hom.ml
+++ b/src/noconf_hom.ml
@@ -228,7 +228,7 @@ let derive_no_confusion_hom ~pm env sigma0 ~poly (ind,u as indu) =
     Covering.{
       program_mode = false;
       rec_type = [None];
-      flags = { poly = poly; open_proof = false;
+      flags = { poly = poly; obligations = false; open_proof = false;
                 with_eqns = false; with_ind = false; 
                 allow_aliases = true; (* We let the compiler unify arguments that are forced equal *)
                 tactic = !Declare.Obls.default_tactic };

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -276,6 +276,9 @@ let tactic_parser : qualid Attributes.key_parser = fun ?loc orig args ->
 let equations_tactic =
   Attributes.attribute_of_list ["tactic",tactic_parser]
 
+let equations_obligations =
+  Attributes.bool_attribute ~name:"obligations"
+
 type rec_type_item =
   | Guarded of (Id.t * rec_annot) list (* for mutual rec *)
   | Logical of int * Id.t with_loc (* for nested wf rec: number of arguments before the side-condition *)

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -191,3 +191,4 @@ val is_recursive : Names.Id.t -> pre_equation wheres -> bool
 val equations_attributes : Attributes.vernac_flags -> equation_user_option list
 val derive_flags : (bool option * bool option) Attributes.attribute
 val equations_tactic : Libnames.qualid option Attributes.attribute
+val equations_obligations : bool option Attributes.attribute

--- a/test-suite/attributes.v
+++ b/test-suite/attributes.v
@@ -4,7 +4,7 @@ Ltac solvetac :=
   match goal with |- ?T => exact 0 end.
 
 Module WithProgram.
-  #[tactic=idtac]
+  #[tactic=idtac,program]
   Equations foo (x : nat) : nat :=
   | 0 => 0
   | S n => S _.
@@ -39,7 +39,7 @@ Module QualifiedTactic.
     | x := _.
 
   (* equations_simpl doesn't *)
-  #[tactic="Equations.CoreTactics.equations_simplify"]
+  #[tactic="Equations.CoreTactics.equations_simplify",obligations]
   Equations bar (x : nat) : nat :=
     | x := _.
     Next Obligation. exact 0. Qed.


### PR DESCRIPTION
This allows to configure the default mode to treat remaining holes. The option can be set to open the proof mode by default, which plays much better with sound minimization of universes and can avoid useless definitions. Obligations are used only if the global option is set (the default, for backward compatibility), the [obligations] attribute is given or the [program_mode] attribute is given and no [obligations=no] is given, i.e. [program_mode] implies [obligations] by default. To be backward and forward compatible with the incoming change of the default when the the new universe minimization lands in Rocq, one just needs to do [Global Set Equations Obligations].