### PR TITLE
Adapt to Rocq PR #19404

### DIFF
--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -308,7 +308,7 @@ let free_vars_of_constr_expr env sigma fid c =
              else l
            | Globnames.Abbrev _ -> l
          with Not_found -> Id.Set.add id l)
-    | { CAst.v = CNotation (_,(InConstrEntry, "?( _ )"), _) } -> l
+    | { CAst.v = CNotation (_, {ntn_entry = InConstrEntry; ntn_key = "?( _ )"}, _) } -> l
     | c -> fold_constr_expr_with_binders (fun a l -> a::l) aux bdvars l c
   in aux [] Id.Set.empty c
 


### PR DESCRIPTION
The type "notation" moved from a pair to a record.

To be merged synchronously with rocq-prover/rocq#19404